### PR TITLE
[마이페이지] 작성 글, 좋아요 기록. 유저 정보

### DIFF
--- a/service-post/src/main/java/com/team13/servicepost/controller/PostController.java
+++ b/service-post/src/main/java/com/team13/servicepost/controller/PostController.java
@@ -9,6 +9,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
 import java.util.Optional;
 
 @RestController
@@ -61,5 +62,15 @@ public class PostController {
     public ResponseEntity<Long> getLikesCount(@PathVariable Long postId) {
         Long likesCount = likePostService.getLikesCount(postId);
         return ResponseEntity.ok(likesCount);
+    }
+
+    @GetMapping("/user/{userId}")
+    public ResponseEntity<List<PostResponseDto>> getPostsByUserId(@PathVariable("userId") Long userId) {
+        List<PostResponseDto> posts = postService.getPostsByUserId(userId);
+        if (posts.isEmpty()) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(null);
+        } else {
+            return ResponseEntity.ok(posts);
+        }
     }
 }

--- a/service-post/src/main/java/com/team13/servicepost/controller/PostController.java
+++ b/service-post/src/main/java/com/team13/servicepost/controller/PostController.java
@@ -1,5 +1,6 @@
 package com.team13.servicepost.controller;
 
+import com.team13.servicepost.dto.MypagePostResponseDto;
 import com.team13.servicepost.dto.PostRequestDto;
 import com.team13.servicepost.dto.PostResponseDto;
 import com.team13.servicepost.service.LikePostService;
@@ -65,8 +66,8 @@ public class PostController {
     }
 
     @GetMapping("/user/{userId}")
-    public ResponseEntity<List<PostResponseDto>> getPostsByUserId(@PathVariable("userId") Long userId) {
-        List<PostResponseDto> posts = postService.getPostsByUserId(userId);
+    public ResponseEntity<List<MypagePostResponseDto>> getPostsByUserId(@PathVariable("userId") Long userId) {
+        List<MypagePostResponseDto> posts = postService.getPostsByUserId(userId);
         if (posts.isEmpty()) {
             return ResponseEntity.status(HttpStatus.NOT_FOUND).body(null);
         } else {
@@ -76,8 +77,8 @@ public class PostController {
 
     // 사용자가 좋아요한 게시글 가져오기
     @GetMapping("/like/user/{userId}")
-    public ResponseEntity<List<PostResponseDto>> getLikePostsByUserId(@PathVariable("userId") Long userId) {
-        List<PostResponseDto> likedPosts = postService.getLikePostsByUserId(userId);
+    public ResponseEntity<List<MypagePostResponseDto>> getLikePostsByUserId(@PathVariable("userId") Long userId) {
+        List<MypagePostResponseDto> likedPosts = postService.getLikePostsByUserId(userId);
         if (likedPosts.isEmpty()) {
             return ResponseEntity.status(HttpStatus.NOT_FOUND).body(null);
         } else {

--- a/service-post/src/main/java/com/team13/servicepost/controller/PostController.java
+++ b/service-post/src/main/java/com/team13/servicepost/controller/PostController.java
@@ -73,4 +73,15 @@ public class PostController {
             return ResponseEntity.ok(posts);
         }
     }
+
+    // 사용자가 좋아요한 게시글 가져오기
+    @GetMapping("/like/user/{userId}")
+    public ResponseEntity<List<PostResponseDto>> getLikePostsByUserId(@PathVariable("userId") Long userId) {
+        List<PostResponseDto> likedPosts = postService.getLikePostsByUserId(userId);
+        if (likedPosts.isEmpty()) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(null);
+        } else {
+            return ResponseEntity.ok(likedPosts);
+        }
+    }
 }

--- a/service-post/src/main/java/com/team13/servicepost/dto/MypagePostResponseDto.java
+++ b/service-post/src/main/java/com/team13/servicepost/dto/MypagePostResponseDto.java
@@ -1,0 +1,28 @@
+package com.team13.servicepost.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.Date;
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class MypagePostResponseDto {
+    private Long id;
+    private Long userId;
+    private int status;
+    private int groupSize;
+    private int curGroupSize;
+    private Date createdAt;
+    private Date closedAt;
+    private String title;
+    private int pricePerUser;
+    private int type;
+    private String contents;
+    private String userNickname;
+    private List<PostIngredientDto> ingredients;
+    private Long likesCount;
+}

--- a/service-post/src/main/java/com/team13/servicepost/repository/LikePostRepository.java
+++ b/service-post/src/main/java/com/team13/servicepost/repository/LikePostRepository.java
@@ -1,14 +1,17 @@
 package com.team13.servicepost.repository;
 
+import com.team13.servicepost.dto.PostResponseDto;
 import com.team13.servicepost.entity.LikePost;
+import com.team13.servicepost.entity.Post;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
 public interface LikePostRepository extends JpaRepository<LikePost, Long> {
     Long countByPostId(Long postId);
     Optional<LikePost> findByPostIdAndUserId(Long postId, Long userId);
-
+    List<LikePost> findByUserId(Long userId);
 }

--- a/service-post/src/main/java/com/team13/servicepost/repository/PostRepository.java
+++ b/service-post/src/main/java/com/team13/servicepost/repository/PostRepository.java
@@ -4,7 +4,10 @@ import com.team13.servicepost.entity.Post;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface PostRepository extends JpaRepository<Post, Long> {
     List<Post> findAllByUserId(Long userId);
+
+    Optional<Post> findById(Long postId);
 }

--- a/service-post/src/main/java/com/team13/servicepost/repository/PostRepository.java
+++ b/service-post/src/main/java/com/team13/servicepost/repository/PostRepository.java
@@ -3,5 +3,8 @@ package com.team13.servicepost.repository;
 import com.team13.servicepost.entity.Post;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface PostRepository extends JpaRepository<Post, Long> {
+    List<Post> findAllByUserId(Long userId);
 }

--- a/service-post/src/main/java/com/team13/servicepost/service/LikePostService.java
+++ b/service-post/src/main/java/com/team13/servicepost/service/LikePostService.java
@@ -1,5 +1,6 @@
 package com.team13.servicepost.service;
 
+import com.team13.servicepost.dto.PostResponseDto;
 import com.team13.servicepost.dto.UserDto;
 import com.team13.servicepost.entity.LikePost;
 import com.team13.servicepost.entity.Post;
@@ -12,7 +13,9 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 
 @Service
@@ -60,4 +63,13 @@ public class LikePostService {
     public Long getLikesCount(Long postId) {
         return likePostRepository.countByPostId(postId);
     }
+
+    // 특정 사용자가 좋아요한 게시글 ID 리스트를 반환하는 메서드
+    public List<Long> getLikedPostIdsByUserId(Long userId) {
+        List<LikePost> likedPosts = likePostRepository.findByUserId(userId);
+        return likedPosts.stream()
+                .map(likePost -> likePost.getPost().getId()) // 각 LikePost 엔티티에서 Post의 ID를 가져옴
+                .collect(Collectors.toList());
+    }
+
 }

--- a/service-post/src/main/java/com/team13/servicepost/service/PostService.java
+++ b/service-post/src/main/java/com/team13/servicepost/service/PostService.java
@@ -184,24 +184,26 @@ public class PostService {
         return postResponseDto;
     }
 
-    public List<PostResponseDto> getPostsByUserId(Long userId) {
+    public List<MypagePostResponseDto> getPostsByUserId(Long userId) {
+        // 사용자가 작성한 모든 게시글을 가져옵니다.
         List<Post> posts = postRepository.findAllByUserId(userId);
 
+        // 각 게시글을 MypagePostResponseDto로 변환하여 리스트로 반환합니다.
         return posts.stream()
                 .map(post -> {
+                    // 게시글 작성자의 닉네임을 가져옵니다.
                     String userNickname = fetchUserNickname(post.getUserId());
+                    // 게시글의 좋아요 개수를 가져옵니다.
                     Long likesCount = likePostService.getLikesCount(post.getId());
-                    return buildPostResponseDto(post, userNickname, likesCount);
+                    // 게시글을 MypagePostResponseDto로 변환합니다.
+                    return buildMypagePostResponseDto(post, userNickname, likesCount);
                 })
                 .collect(Collectors.toList());
     }
 
-    // 좋아요한 게시글을 가져오기 위한 메서드
-    public List<PostResponseDto> getLikePostsByUserId(Long userId) {
-        // LikePostService를 사용하여 사용자가 좋아요한 Post ID 리스트를 가져옴
+    public List<MypagePostResponseDto> getLikePostsByUserId(Long userId) {
         List<Long> likedPostIds = likePostService.getLikedPostIdsByUserId(userId);
 
-        // 각 Post ID를 사용하여 Post 엔티티를 조회하고, PostResponseDto로 변환
         return likedPostIds.stream()
                 .map(postId -> postRepository.findById(postId))
                 .filter(Optional::isPresent)
@@ -209,9 +211,35 @@ public class PostService {
                 .map(post -> {
                     String userNickname = fetchUserNickname(post.getUserId());
                     Long likesCount = likePostService.getLikesCount(post.getId());
-                    return buildPostResponseDto(post, userNickname, likesCount);
+                    return buildMypagePostResponseDto(post, userNickname, likesCount);
                 })
                 .collect(Collectors.toList());
+    }
+
+
+
+    private MypagePostResponseDto buildMypagePostResponseDto(Post post, String userNickname, Long likesCount) {
+        List<PostIngredient> ingredients = postIngredientService.getIngredientsByPostId(post.getId());
+        List<PostIngredientDto> ingredientDto = ingredients.stream()
+                .map(postIngredientService::convertToDto)
+                .collect(Collectors.toList());
+
+        MypagePostResponseDto postResponseDto = new MypagePostResponseDto();
+        postResponseDto.setId(post.getId());
+        postResponseDto.setUserId(post.getUserId());
+        postResponseDto.setStatus(post.getStatus());
+        postResponseDto.setGroupSize(post.getGroupSize());
+        postResponseDto.setCurGroupSize(post.getCurGroupSize());
+        postResponseDto.setCreatedAt(post.getCreatedAt());
+        postResponseDto.setClosedAt(post.getClosedAt());
+        postResponseDto.setTitle(post.getTitle());
+        postResponseDto.setPricePerUser(post.getPricePerUser());
+        postResponseDto.setType(post.getType());
+        postResponseDto.setContents(post.getContents());
+        postResponseDto.setUserNickname(userNickname);
+        postResponseDto.setIngredients(ingredientDto);
+        postResponseDto.setLikesCount(likesCount);
+        return postResponseDto;
     }
 
 

--- a/service-post/src/main/java/com/team13/servicepost/service/PostService.java
+++ b/service-post/src/main/java/com/team13/servicepost/service/PostService.java
@@ -1,10 +1,12 @@
 package com.team13.servicepost.service;
 
 import com.team13.servicepost.dto.*;
+import com.team13.servicepost.entity.LikePost;
 import com.team13.servicepost.entity.Post;
 import com.team13.servicepost.entity.PostImage;
 import com.team13.servicepost.entity.PostIngredient;
 import com.team13.servicepost.feign.UserServiceClient;
+import com.team13.servicepost.repository.LikePostRepository;
 import com.team13.servicepost.repository.PostRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
@@ -20,6 +22,9 @@ public class PostService {
 
     @Autowired
     private PostRepository postRepository;
+
+    @Autowired
+    private LikePostRepository likePostRepository;
 
     @Autowired
     private PostImageService postImageService;
@@ -190,4 +195,24 @@ public class PostService {
                 })
                 .collect(Collectors.toList());
     }
+
+    // 좋아요한 게시글을 가져오기 위한 메서드
+    public List<PostResponseDto> getLikePostsByUserId(Long userId) {
+        // LikePostService를 사용하여 사용자가 좋아요한 Post ID 리스트를 가져옴
+        List<Long> likedPostIds = likePostService.getLikedPostIdsByUserId(userId);
+
+        // 각 Post ID를 사용하여 Post 엔티티를 조회하고, PostResponseDto로 변환
+        return likedPostIds.stream()
+                .map(postId -> postRepository.findById(postId))
+                .filter(Optional::isPresent)
+                .map(Optional::get)
+                .map(post -> {
+                    String userNickname = fetchUserNickname(post.getUserId());
+                    Long likesCount = likePostService.getLikesCount(post.getId());
+                    return buildPostResponseDto(post, userNickname, likesCount);
+                })
+                .collect(Collectors.toList());
+    }
+
+
 }

--- a/service-post/src/main/java/com/team13/servicepost/service/PostService.java
+++ b/service-post/src/main/java/com/team13/servicepost/service/PostService.java
@@ -178,4 +178,16 @@ public class PostService {
 
         return postResponseDto;
     }
+
+    public List<PostResponseDto> getPostsByUserId(Long userId) {
+        List<Post> posts = postRepository.findAllByUserId(userId);
+
+        return posts.stream()
+                .map(post -> {
+                    String userNickname = fetchUserNickname(post.getUserId());
+                    Long likesCount = likePostService.getLikesCount(post.getId());
+                    return buildPostResponseDto(post, userNickname, likesCount);
+                })
+                .collect(Collectors.toList());
+    }
 }

--- a/service-recipe/src/main/java/com/team13/servicerecipe/controller/RecipeController.java
+++ b/service-recipe/src/main/java/com/team13/servicerecipe/controller/RecipeController.java
@@ -11,6 +11,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
 import java.util.Optional;
 
 @RestController
@@ -62,6 +63,16 @@ public class RecipeController {
     public ResponseEntity<Long> getLikesCount(@PathVariable Long recipeId) {
         Long likesCount = likeRecipeService.getLikesCount(recipeId);
         return ResponseEntity.ok(likesCount);
+    }
+
+    @GetMapping("/user/{userId}")
+    public ResponseEntity<List<RecipeResponseDto>> getRecipesByUserId(@PathVariable("userId") Long userId) {
+        List<RecipeResponseDto> recipes = recipeService.getRecipesByUserId(userId);
+        if (recipes.isEmpty()) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(null);
+        } else {
+            return ResponseEntity.ok(recipes);
+        }
     }
 
 

--- a/service-recipe/src/main/java/com/team13/servicerecipe/controller/RecipeController.java
+++ b/service-recipe/src/main/java/com/team13/servicerecipe/controller/RecipeController.java
@@ -1,6 +1,7 @@
 package com.team13.servicerecipe.controller;
 
 
+import com.team13.servicerecipe.dto.MypageRecipeResponseDto;
 import com.team13.servicerecipe.dto.RecipeRequestDto;
 import com.team13.servicerecipe.dto.RecipeResponseDto;
 import com.team13.servicerecipe.entity.Recipe;
@@ -66,8 +67,8 @@ public class RecipeController {
     }
 
     @GetMapping("/user/{userId}")
-    public ResponseEntity<List<RecipeResponseDto>> getRecipesByUserId(@PathVariable("userId") Long userId) {
-        List<RecipeResponseDto> recipes = recipeService.getRecipesByUserId(userId);
+    public ResponseEntity<List<MypageRecipeResponseDto>> getRecipesByUserId(@PathVariable("userId") Long userId) {
+        List<MypageRecipeResponseDto> recipes = recipeService.getRecipesByUserId(userId);
         if (recipes.isEmpty()) {
             return ResponseEntity.status(HttpStatus.NOT_FOUND).body(null);
         } else {
@@ -76,8 +77,8 @@ public class RecipeController {
     }
 
     @GetMapping("/like/user/{userId}")
-    public ResponseEntity<List<RecipeResponseDto>> getLikeRecipesByUserId(@PathVariable("userId") Long userId) {
-        List<RecipeResponseDto> likedRecipes = recipeService.getLikeRecipesByUserId(userId);
+    public ResponseEntity<List<MypageRecipeResponseDto>> getLikeRecipesByUserId(@PathVariable("userId") Long userId) {
+        List<MypageRecipeResponseDto> likedRecipes = recipeService.getLikeRecipesByUserId(userId);
         if (likedRecipes.isEmpty()) {
             return ResponseEntity.status(HttpStatus.NOT_FOUND).body(null);
         } else {

--- a/service-recipe/src/main/java/com/team13/servicerecipe/controller/RecipeController.java
+++ b/service-recipe/src/main/java/com/team13/servicerecipe/controller/RecipeController.java
@@ -75,5 +75,15 @@ public class RecipeController {
         }
     }
 
+    @GetMapping("/like/user/{userId}")
+    public ResponseEntity<List<RecipeResponseDto>> getLikeRecipesByUserId(@PathVariable("userId") Long userId) {
+        List<RecipeResponseDto> likedRecipes = recipeService.getLikeRecipesByUserId(userId);
+        if (likedRecipes.isEmpty()) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(null);
+        } else {
+            return ResponseEntity.ok(likedRecipes);
+        }
+    }
+
 
 }

--- a/service-recipe/src/main/java/com/team13/servicerecipe/dto/MypageRecipeResponseDto.java
+++ b/service-recipe/src/main/java/com/team13/servicerecipe/dto/MypageRecipeResponseDto.java
@@ -1,0 +1,25 @@
+package com.team13.servicerecipe.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.Date;
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class MypageRecipeResponseDto {
+    private Long id;
+    private Long userId;
+    private String title;
+    private String contents;
+    private int commentCount;
+    private String thumbnailImagePath;
+    private Date createdAt;
+    private int type;
+    private String userNickname;
+    private List<RecipeIngredientDto> ingredients;
+    private Long likesCount;
+}

--- a/service-recipe/src/main/java/com/team13/servicerecipe/repository/LikeRecipeRepository.java
+++ b/service-recipe/src/main/java/com/team13/servicerecipe/repository/LikeRecipeRepository.java
@@ -3,9 +3,12 @@ package com.team13.servicerecipe.repository;
 import com.team13.servicerecipe.entity.LikeRecipe;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface LikeRecipeRepository extends JpaRepository<LikeRecipe, Long> {
     Long countByRecipeId(Long recipeId);
     Optional<LikeRecipe> findByRecipeIdAndUserId(Long recipeId, Long userId);
+
+    List<LikeRecipe> findByUserId(Long userId);
 }

--- a/service-recipe/src/main/java/com/team13/servicerecipe/repository/RecipeRepository.java
+++ b/service-recipe/src/main/java/com/team13/servicerecipe/repository/RecipeRepository.java
@@ -3,5 +3,8 @@ package com.team13.servicerecipe.repository;
 import com.team13.servicerecipe.entity.Recipe;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface RecipeRepository extends JpaRepository<Recipe, Long> {
+    List<Recipe> findAllByUserId(Long userId);
 }

--- a/service-recipe/src/main/java/com/team13/servicerecipe/repository/RecipeRepository.java
+++ b/service-recipe/src/main/java/com/team13/servicerecipe/repository/RecipeRepository.java
@@ -4,7 +4,10 @@ import com.team13.servicerecipe.entity.Recipe;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface RecipeRepository extends JpaRepository<Recipe, Long> {
     List<Recipe> findAllByUserId(Long userId);
+
+    Optional<Recipe> findById(Long recipeId);
 }

--- a/service-recipe/src/main/java/com/team13/servicerecipe/service/LikeRecipeService.java
+++ b/service-recipe/src/main/java/com/team13/servicerecipe/service/LikeRecipeService.java
@@ -12,7 +12,9 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 @Service
 public class LikeRecipeService {
@@ -58,5 +60,12 @@ public class LikeRecipeService {
 
     public Long getLikesCount(Long recipeId) {
         return likeRecipeRepository.countByRecipeId(recipeId);
+    }
+
+    public List<Long> getLikedRecipeIdsByUserId(Long userId) {
+        List<LikeRecipe> likedRecipes = likeRecipeRepository.findByUserId(userId);
+        return likedRecipes.stream()
+                .map(likeRecipe -> likeRecipe.getRecipe().getId())
+                .collect(Collectors.toList());
     }
 }

--- a/service-recipe/src/main/java/com/team13/servicerecipe/service/RecipeService.java
+++ b/service-recipe/src/main/java/com/team13/servicerecipe/service/RecipeService.java
@@ -100,9 +100,9 @@ public class RecipeService {
 
         String userNickname = fetchUserNickname(recipe.getUserId());
         Long likesCount = 0L;
-        Long commentCount =0L;
 
-        return buildRecipeResponseDto(savedRecipe, userNickname, likesCount, commentCount);
+
+        return buildRecipeResponseDto(savedRecipe, userNickname, likesCount);
     }
 
     public Optional<RecipeResponseDto> getRecipeWithUserDetails(Long recipeId) {
@@ -114,10 +114,10 @@ public class RecipeService {
         Recipe recipe = recipeOptional.get();
         String userNickname = fetchUserNickname(recipe.getUserId());
         Long likesCount = likeRecipeService.getLikesCount(recipeId);
-        Long commentCount= likeRecipeService.getLikesCount(recipeId);
 
 
-        return Optional.of(buildRecipeResponseDto(recipe, userNickname, likesCount, commentCount));
+
+        return Optional.of(buildRecipeResponseDto(recipe, userNickname, likesCount));
     }
 
     private String fetchUserNickname(Long userId) {
@@ -129,7 +129,7 @@ public class RecipeService {
     }
 
 
-    private RecipeResponseDto buildRecipeResponseDto(Recipe recipe, String userNickname ,Long likesCount ,Long commentCount) {
+    private RecipeResponseDto buildRecipeResponseDto(Recipe recipe, String userNickname ,Long likesCount) {
         List<RecipeIngredient> ingredients = recipeIngredientService.getIngredientsByRecipeId(recipe.getId());
         List<RecipeIngredientDto> ingredientDto = ingredients.stream()
                 .map(recipeIngredientService::convertToDto)
@@ -155,6 +155,18 @@ public class RecipeService {
         recipeResponseDto.setLikesCount(likesCount);
 
         return recipeResponseDto;
+    }
+
+    public List<RecipeResponseDto> getRecipesByUserId(Long userId) {
+        List<Recipe> recipes = recipeRepository.findAllByUserId(userId);
+
+        return recipes.stream()
+                .map(recipe -> {
+                    String userNickname = fetchUserNickname(recipe.getUserId());
+                    Long likesCount = likeRecipeService.getLikesCount(recipe.getId());
+                    return buildRecipeResponseDto(recipe, userNickname, likesCount);
+                })
+                .collect(Collectors.toList());
     }
 
 }

--- a/service-recipe/src/main/java/com/team13/servicerecipe/service/RecipeService.java
+++ b/service-recipe/src/main/java/com/team13/servicerecipe/service/RecipeService.java
@@ -169,4 +169,22 @@ public class RecipeService {
                 .collect(Collectors.toList());
     }
 
+    public List<RecipeResponseDto> getLikeRecipesByUserId(Long userId) {
+        // LikePostService를 사용하여 사용자가 좋아요한 Post ID 리스트를 가져옴
+        List<Long> likedRecipeIds = likeRecipeService.getLikedRecipeIdsByUserId(userId);
+
+        // 각 Post ID를 사용하여 Post 엔티티를 조회하고, PostResponseDto로 변환
+        return likedRecipeIds.stream()
+                .map(recipeId -> recipeRepository.findById(recipeId))
+                .filter(Optional::isPresent)
+                .map(Optional::get)
+                .map(recipe -> {
+                    String userNickname = fetchUserNickname(recipe.getUserId());
+                    Long likesCount = likeRecipeService.getLikesCount(recipe.getId());
+                    return buildRecipeResponseDto(recipe, userNickname, likesCount);
+                })
+                .collect(Collectors.toList());
+    }
+
+
 }

--- a/service-recipe/src/main/java/com/team13/servicerecipe/service/RecipeService.java
+++ b/service-recipe/src/main/java/com/team13/servicerecipe/service/RecipeService.java
@@ -157,19 +157,19 @@ public class RecipeService {
         return recipeResponseDto;
     }
 
-    public List<RecipeResponseDto> getRecipesByUserId(Long userId) {
+    public List<MypageRecipeResponseDto> getRecipesByUserId(Long userId) {
         List<Recipe> recipes = recipeRepository.findAllByUserId(userId);
 
         return recipes.stream()
                 .map(recipe -> {
                     String userNickname = fetchUserNickname(recipe.getUserId());
                     Long likesCount = likeRecipeService.getLikesCount(recipe.getId());
-                    return buildRecipeResponseDto(recipe, userNickname, likesCount);
+                    return buildMypageRecipeResponseDto(recipe, userNickname, likesCount);
                 })
                 .collect(Collectors.toList());
     }
 
-    public List<RecipeResponseDto> getLikeRecipesByUserId(Long userId) {
+    public List<MypageRecipeResponseDto> getLikeRecipesByUserId(Long userId) {
         // LikePostService를 사용하여 사용자가 좋아요한 Post ID 리스트를 가져옴
         List<Long> likedRecipeIds = likeRecipeService.getLikedRecipeIdsByUserId(userId);
 
@@ -181,9 +181,31 @@ public class RecipeService {
                 .map(recipe -> {
                     String userNickname = fetchUserNickname(recipe.getUserId());
                     Long likesCount = likeRecipeService.getLikesCount(recipe.getId());
-                    return buildRecipeResponseDto(recipe, userNickname, likesCount);
+                    return buildMypageRecipeResponseDto(recipe, userNickname, likesCount);
                 })
                 .collect(Collectors.toList());
+    }
+
+    private MypageRecipeResponseDto buildMypageRecipeResponseDto(Recipe recipe, String userNickname ,Long likesCount) {
+        List<RecipeIngredient> ingredients = recipeIngredientService.getIngredientsByRecipeId(recipe.getId());
+        List<RecipeIngredientDto> ingredientDto = ingredients.stream()
+                .map(recipeIngredientService::convertToDto)
+                .collect(Collectors.toList());
+
+        MypageRecipeResponseDto recipeResponseDto = new MypageRecipeResponseDto();
+        recipeResponseDto.setId(recipe.getId());
+        recipeResponseDto.setUserId(recipe.getUserId());
+        recipeResponseDto.setTitle(recipe.getTitle());
+        recipeResponseDto.setContents(recipe.getContents());
+        recipeResponseDto.setCommentCount(recipe.getCommentCount());
+        recipeResponseDto.setThumbnailImagePath(recipe.getThumbnailImagePath());
+        recipeResponseDto.setCreatedAt(recipe.getCreatedAt());
+        recipeResponseDto.setType(recipe.getType());
+        recipeResponseDto.setUserNickname(userNickname);
+        recipeResponseDto.setIngredients(ingredientDto);
+        recipeResponseDto.setLikesCount(likesCount);
+
+        return recipeResponseDto;
     }
 
 

--- a/service-user/src/main/java/com/team13/serviceuser/controller/IndexController.java
+++ b/service-user/src/main/java/com/team13/serviceuser/controller/IndexController.java
@@ -3,9 +3,11 @@ package com.team13.serviceuser.controller;
 import com.team13.serviceuser.dto.JoinRequestDto;
 import com.team13.serviceuser.dto.LoginRequestDto;
 import com.team13.serviceuser.dto.ResponseDto;
+import com.team13.serviceuser.dto.UserDto;
 import com.team13.serviceuser.entity.User;
 import com.team13.serviceuser.service.SignInService;
 import com.team13.serviceuser.service.SignUpService;
+import com.team13.serviceuser.util.RandomUserGenerator;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
@@ -27,59 +29,8 @@ public class IndexController {
     @Value("${app.test-string}")
     private String configTestString;
 
-    private final SignInService signInService;
-    private final SignUpService signUpService;
-
     @GetMapping
     public String index() { return "Index page of service-user"; }
-
-    //회원가입 요청
-    // 회원가입 요청
-    @PostMapping("/join")
-        public ResponseEntity<String> join (@Valid @RequestBody JoinRequestDto joinRequestDto,
-                                            BindingResult bindingResult) {
-        //request전달 값 조건 에러시 메세지
-            if (bindingResult.hasErrors()) {
-                String errorMessages = bindingResult.getAllErrors()
-                        .stream()
-                        .map(ObjectError::getDefaultMessage)
-                        .reduce((message1, message2) -> message1 + "; " + message2)
-                        .orElse("Validation failed.");
-                return ResponseEntity.badRequest().body(errorMessages);
-            }
-
-            //이메일 중복 체크
-            if (signUpService.checkEmailDuplicate(joinRequestDto.getEmail())) {
-                return ResponseEntity.badRequest().body("이메일이 중복됩니다.");
-            }
-
-            // 닉네임 중복 체크
-            if (signUpService.checkNicknameDuplicate(joinRequestDto.getNickname())) {
-                return ResponseEntity.badRequest().body("닉네임이 중복됩니다.");
-            }
-
-            // password와 passwordCheck가 같은지 체크
-            if (!joinRequestDto.getPassword().equals(joinRequestDto.getPasswordCheck())) {
-                return ResponseEntity.badRequest().body("비밀번호가 일치하지 않습니다.");
-            }
-
-            signUpService.join(joinRequestDto);
-            return ResponseEntity.ok("회원가입 성공");
-        }
-
-    // 로그인 요청
-    // 로그인 성공 시 클라이언트에게 JWT 토큰을 반환함
-    @PostMapping("/login")
-    public  ResponseEntity<String> login (@RequestBody LoginRequestDto loginRequestDto,
-                                          HttpServletResponse response) {
-        User user = signInService.login(loginRequestDto);
-        if (user == null) {
-            ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
-        }
-        Cookie cookie = signInService.createCookieFromUser(user);
-        response.addCookie(cookie);
-        return ResponseEntity.ok().build();
-    }
 
     @GetMapping("/config")
     public String getConfig() { return configTestString; }
@@ -87,6 +38,23 @@ public class IndexController {
     @GetMapping("/service-connection-test")
     public ResponseDto serviceConnectionTest() {
         return new ResponseDto("Greeting!!");
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<UserDto> getUserById(@PathVariable Long id) {
+        // 임의의 닉네임 생성
+        String emailId = RandomUserGenerator.generateEmailId();
+
+        // UserDto 객체 생성
+        UserDto userDto = UserDto.builder()
+                .id(id)
+                .email(RandomUserGenerator.generateEmail(emailId))
+                .nickname(RandomUserGenerator.generateNickname())
+                .userRating(RandomUserGenerator.generateUserRating())
+                .profileImageUrl(RandomUserGenerator.generateProfileImageUrl())
+                .build();
+
+        return new ResponseEntity<>(userDto, HttpStatus.OK);
     }
 
 }

--- a/service-user/src/main/java/com/team13/serviceuser/controller/MypageController.java
+++ b/service-user/src/main/java/com/team13/serviceuser/controller/MypageController.java
@@ -6,6 +6,7 @@ import com.team13.serviceuser.dto.RecipeResponseDto;
 import com.team13.serviceuser.dto.UserDto;
 import com.team13.serviceuser.service.MyPageService;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -44,6 +45,16 @@ public class MypageController {
     public ResponseEntity<List<RecipeResponseDto>> getRecipesByUserId(@PathVariable Long userId) {
         List<RecipeResponseDto> recipes = myPageService.getRecipesByUserId(userId);
         return ResponseEntity.ok(recipes);
+    }
+
+    @GetMapping("/user/{userId}/likePosts")
+    public ResponseEntity<List<PostResponseDto>> getLikePostsByUserId(@PathVariable Long userId) {
+        List<PostResponseDto> likedPosts = myPageService.getLikePostsByUserId(userId);
+        if (likedPosts.isEmpty()) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(null);
+        } else {
+            return ResponseEntity.ok(likedPosts);
+        }
     }
 
 

--- a/service-user/src/main/java/com/team13/serviceuser/controller/MypageController.java
+++ b/service-user/src/main/java/com/team13/serviceuser/controller/MypageController.java
@@ -1,6 +1,7 @@
 package com.team13.serviceuser.controller;
 
 import com.team13.serviceuser.dto.PostResponseDto;
+import com.team13.serviceuser.dto.UserDto;
 import com.team13.serviceuser.service.MyPageService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
@@ -22,6 +23,14 @@ public class MypageController {
         this.myPageService = myPageService;
     }
 
+    // 사용자 정보 가져오기
+    @GetMapping("/user/{userId}")
+    public ResponseEntity<UserDto> getUserById(@PathVariable Long userId) {
+        UserDto user = myPageService.getUserById(userId);
+        return ResponseEntity.ok(user);
+    }
+
+    // 사용자가 작성한 글 가져오기
     @GetMapping("/user/{userId}/posts")
     public ResponseEntity<List<PostResponseDto>> getPostsByUserId(@PathVariable Long userId) {
         List<PostResponseDto> posts = myPageService.getPostsByUserId(userId);

--- a/service-user/src/main/java/com/team13/serviceuser/controller/MypageController.java
+++ b/service-user/src/main/java/com/team13/serviceuser/controller/MypageController.java
@@ -47,6 +47,7 @@ public class MypageController {
         return ResponseEntity.ok(recipes);
     }
 
+    //사용자가 좋아요 누른 공동구매게시글
     @GetMapping("/user/{userId}/likePosts")
     public ResponseEntity<List<PostResponseDto>> getLikePostsByUserId(@PathVariable Long userId) {
         List<PostResponseDto> likedPosts = myPageService.getLikePostsByUserId(userId);
@@ -54,6 +55,18 @@ public class MypageController {
             return ResponseEntity.status(HttpStatus.NOT_FOUND).body(null);
         } else {
             return ResponseEntity.ok(likedPosts);
+        }
+    }
+
+
+    //사용자가 좋아요 누른 레시피
+    @GetMapping("/user/{userId}/likeRecipes")
+    public ResponseEntity<List<RecipeResponseDto>> getLikeRecipesByUserId(@PathVariable Long userId) {
+        List<RecipeResponseDto> likedRecipes = myPageService.getLikeRecipesByUserId(userId);
+        if (likedRecipes.isEmpty()) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(null);
+        } else {
+            return ResponseEntity.ok(likedRecipes);
         }
     }
 

--- a/service-user/src/main/java/com/team13/serviceuser/controller/MypageController.java
+++ b/service-user/src/main/java/com/team13/serviceuser/controller/MypageController.java
@@ -1,14 +1,13 @@
 package com.team13.serviceuser.controller;
 
 import com.team13.serviceuser.dto.*;
+import com.team13.serviceuser.entity.User;
+import com.team13.serviceuser.repository.UserRepository;
 import com.team13.serviceuser.service.MyPageService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -17,6 +16,7 @@ import java.util.List;
 public class MypageController {
 
     private final MyPageService myPageService;
+
 
     @Autowired
     public MypageController(MyPageService myPageService) {
@@ -67,5 +67,10 @@ public class MypageController {
         }
     }
 
+    @PutMapping("/user/{userId}")
+    public ResponseEntity<UserDto> updateUser(@PathVariable Long userId, @RequestBody UserDto userDto) {
+        UserDto updatedUser = myPageService.updateUser(userId, userDto);
+        return ResponseEntity.ok(updatedUser);
+    }
 
 }

--- a/service-user/src/main/java/com/team13/serviceuser/controller/MypageController.java
+++ b/service-user/src/main/java/com/team13/serviceuser/controller/MypageController.java
@@ -1,6 +1,8 @@
 package com.team13.serviceuser.controller;
 
 import com.team13.serviceuser.dto.PostResponseDto;
+import com.team13.serviceuser.dto.RecipeProcessDto;
+import com.team13.serviceuser.dto.RecipeResponseDto;
 import com.team13.serviceuser.dto.UserDto;
 import com.team13.serviceuser.service.MyPageService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -30,13 +32,19 @@ public class MypageController {
         return ResponseEntity.ok(user);
     }
 
-    // 사용자가 작성한 글 가져오기
+    // 사용자가 작성한 공동구매게시글 가져오기
     @GetMapping("/user/{userId}/posts")
     public ResponseEntity<List<PostResponseDto>> getPostsByUserId(@PathVariable Long userId) {
         List<PostResponseDto> posts = myPageService.getPostsByUserId(userId);
         return ResponseEntity.ok(posts);
     }
 
+    //사용자가 작성한 레시피 가져오기
+    @GetMapping("/user/{userId}/recipes")
+    public ResponseEntity<List<RecipeResponseDto>> getRecipesByUserId(@PathVariable Long userId) {
+        List<RecipeResponseDto> recipes = myPageService.getRecipesByUserId(userId);
+        return ResponseEntity.ok(recipes);
+    }
 
 
 }

--- a/service-user/src/main/java/com/team13/serviceuser/controller/MypageController.java
+++ b/service-user/src/main/java/com/team13/serviceuser/controller/MypageController.java
@@ -1,0 +1,33 @@
+package com.team13.serviceuser.controller;
+
+import com.team13.serviceuser.dto.PostResponseDto;
+import com.team13.serviceuser.service.MyPageService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/mypage")
+public class MypageController {
+
+    private final MyPageService myPageService;
+
+    @Autowired
+    public MypageController(MyPageService myPageService) {
+        this.myPageService = myPageService;
+    }
+
+    @GetMapping("/user/{userId}/posts")
+    public ResponseEntity<List<PostResponseDto>> getPostsByUserId(@PathVariable Long userId) {
+        List<PostResponseDto> posts = myPageService.getPostsByUserId(userId);
+        return ResponseEntity.ok(posts);
+    }
+
+
+
+}

--- a/service-user/src/main/java/com/team13/serviceuser/controller/MypageController.java
+++ b/service-user/src/main/java/com/team13/serviceuser/controller/MypageController.java
@@ -1,9 +1,6 @@
 package com.team13.serviceuser.controller;
 
-import com.team13.serviceuser.dto.PostResponseDto;
-import com.team13.serviceuser.dto.RecipeProcessDto;
-import com.team13.serviceuser.dto.RecipeResponseDto;
-import com.team13.serviceuser.dto.UserDto;
+import com.team13.serviceuser.dto.*;
 import com.team13.serviceuser.service.MyPageService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
@@ -35,22 +32,22 @@ public class MypageController {
 
     // 사용자가 작성한 공동구매게시글 가져오기
     @GetMapping("/user/{userId}/posts")
-    public ResponseEntity<List<PostResponseDto>> getPostsByUserId(@PathVariable Long userId) {
-        List<PostResponseDto> posts = myPageService.getPostsByUserId(userId);
+    public ResponseEntity<List<MypagePostResponseDto>> getPostsByUserId(@PathVariable Long userId) {
+        List<MypagePostResponseDto> posts = myPageService.getPostsByUserId(userId);
         return ResponseEntity.ok(posts);
     }
 
     //사용자가 작성한 레시피 가져오기
     @GetMapping("/user/{userId}/recipes")
-    public ResponseEntity<List<RecipeResponseDto>> getRecipesByUserId(@PathVariable Long userId) {
-        List<RecipeResponseDto> recipes = myPageService.getRecipesByUserId(userId);
+    public ResponseEntity<List<MypageRecipeResponseDto>> getRecipesByUserId(@PathVariable Long userId) {
+        List<MypageRecipeResponseDto> recipes = myPageService.getRecipesByUserId(userId);
         return ResponseEntity.ok(recipes);
     }
 
     //사용자가 좋아요 누른 공동구매게시글
     @GetMapping("/user/{userId}/likePosts")
-    public ResponseEntity<List<PostResponseDto>> getLikePostsByUserId(@PathVariable Long userId) {
-        List<PostResponseDto> likedPosts = myPageService.getLikePostsByUserId(userId);
+    public ResponseEntity<List<MypagePostResponseDto>> getLikePostsByUserId(@PathVariable Long userId) {
+        List<MypagePostResponseDto> likedPosts = myPageService.getLikePostsByUserId(userId);
         if (likedPosts.isEmpty()) {
             return ResponseEntity.status(HttpStatus.NOT_FOUND).body(null);
         } else {
@@ -61,8 +58,8 @@ public class MypageController {
 
     //사용자가 좋아요 누른 레시피
     @GetMapping("/user/{userId}/likeRecipes")
-    public ResponseEntity<List<RecipeResponseDto>> getLikeRecipesByUserId(@PathVariable Long userId) {
-        List<RecipeResponseDto> likedRecipes = myPageService.getLikeRecipesByUserId(userId);
+    public ResponseEntity<List<MypageRecipeResponseDto>> getLikeRecipesByUserId(@PathVariable Long userId) {
+        List<MypageRecipeResponseDto> likedRecipes = myPageService.getLikeRecipesByUserId(userId);
         if (likedRecipes.isEmpty()) {
             return ResponseEntity.status(HttpStatus.NOT_FOUND).body(null);
         } else {

--- a/service-user/src/main/java/com/team13/serviceuser/controller/SignController.java
+++ b/service-user/src/main/java/com/team13/serviceuser/controller/SignController.java
@@ -1,0 +1,80 @@
+package com.team13.serviceuser.controller;
+
+import com.team13.serviceuser.dto.JoinRequestDto;
+import com.team13.serviceuser.dto.LoginRequestDto;
+import com.team13.serviceuser.entity.User;
+import com.team13.serviceuser.service.SignInService;
+import com.team13.serviceuser.service.SignUpService;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.ObjectError;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Log4j2
+@RestController
+@RequestMapping("/sign")
+@RequiredArgsConstructor
+public class SignController {
+
+    private final SignInService signInService;
+    private final SignUpService signUpService;
+
+    //회원가입 요청
+    // 회원가입 요청
+    @PostMapping("/join")
+    public ResponseEntity<String> join (@Valid @RequestBody JoinRequestDto joinRequestDto,
+                                        BindingResult bindingResult) {
+        //request전달 값 조건 에러시 메세지
+        if (bindingResult.hasErrors()) {
+            String errorMessages = bindingResult.getAllErrors()
+                    .stream()
+                    .map(ObjectError::getDefaultMessage)
+                    .reduce((message1, message2) -> message1 + "; " + message2)
+                    .orElse("Validation failed.");
+            return ResponseEntity.badRequest().body(errorMessages);
+        }
+
+        //이메일 중복 체크
+        if (signUpService.checkEmailDuplicate(joinRequestDto.getEmail())) {
+            return ResponseEntity.badRequest().body("이메일이 중복됩니다.");
+        }
+
+        // 닉네임 중복 체크
+        if (signUpService.checkNicknameDuplicate(joinRequestDto.getNickname())) {
+            return ResponseEntity.badRequest().body("닉네임이 중복됩니다.");
+        }
+
+        // password와 passwordCheck가 같은지 체크
+        if (!joinRequestDto.getPassword().equals(joinRequestDto.getPasswordCheck())) {
+            return ResponseEntity.badRequest().body("비밀번호가 일치하지 않습니다.");
+        }
+
+        signUpService.join(joinRequestDto);
+        return ResponseEntity.ok("회원가입 성공");
+    }
+
+    // 로그인 요청
+    // 로그인 성공 시 클라이언트에게 JWT 토큰을 반환함
+    @PostMapping("/login")
+    public  ResponseEntity<String> login (@RequestBody LoginRequestDto loginRequestDto,
+                                          HttpServletResponse response) {
+        User user = signInService.login(loginRequestDto);
+        if (user == null) {
+            ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        }
+        Cookie cookie = signInService.createCookieFromUser(user);
+        response.addCookie(cookie);
+        return ResponseEntity.ok().build();
+    }
+
+
+}

--- a/service-user/src/main/java/com/team13/serviceuser/dto/MypagePostResponseDto.java
+++ b/service-user/src/main/java/com/team13/serviceuser/dto/MypagePostResponseDto.java
@@ -10,26 +10,19 @@ import java.util.List;
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
-
-public class PostResponseDto {
+public class MypagePostResponseDto {
     private Long id;
-    private Long userId; // 나중에 삭제 확인용
+    private Long userId;
     private int status;
     private int groupSize;
     private int curGroupSize;
-    private String chatId;
     private Date createdAt;
     private Date closedAt;
-    private int locationBcode;
-    private String locationAddress;
-    private String locationLongitude;
-    private String locationLatitude;
     private String title;
     private int pricePerUser;
     private int type;
     private String contents;
-    private List<PostImageDto> images;
-    private List<PostIngredientDto> ingredients;
     private String userNickname;
+    private List<PostIngredientDto> ingredients;
     private Long likesCount;
 }

--- a/service-user/src/main/java/com/team13/serviceuser/dto/MypageRecipeResponseDto.java
+++ b/service-user/src/main/java/com/team13/serviceuser/dto/MypageRecipeResponseDto.java
@@ -1,4 +1,5 @@
 package com.team13.serviceuser.dto;
+
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -9,8 +10,7 @@ import java.util.List;
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
-
-public class RecipeResponseDto {
+public class MypageRecipeResponseDto {
     private Long id;
     private Long userId;
     private String title;
@@ -21,6 +21,5 @@ public class RecipeResponseDto {
     private int type;
     private String userNickname;
     private List<RecipeIngredientDto> ingredients;
-    private List<RecipeProcessDto> processes;
     private Long likesCount;
 }

--- a/service-user/src/main/java/com/team13/serviceuser/dto/PostImageDto.java
+++ b/service-user/src/main/java/com/team13/serviceuser/dto/PostImageDto.java
@@ -1,0 +1,10 @@
+package com.team13.serviceuser.dto;
+
+import lombok.Data;
+
+@Data
+public class PostImageDto {
+    private Long id;
+    private Long postId;
+    private String imagePath;
+}

--- a/service-user/src/main/java/com/team13/serviceuser/dto/PostIngredientDto.java
+++ b/service-user/src/main/java/com/team13/serviceuser/dto/PostIngredientDto.java
@@ -1,0 +1,11 @@
+package com.team13.serviceuser.dto;
+
+import lombok.Data;
+
+@Data
+public class PostIngredientDto {
+    private Long id;
+    private Long postId;
+    private String name;
+    private String url;
+}

--- a/service-user/src/main/java/com/team13/serviceuser/dto/PostResponseDto.java
+++ b/service-user/src/main/java/com/team13/serviceuser/dto/PostResponseDto.java
@@ -1,0 +1,35 @@
+package com.team13.serviceuser.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.Date;
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+
+public class PostResponseDto {
+    private Long id;
+    private Long userId; // 나중에 삭제 확인용
+    private int status;
+    private int groupSize;
+    private int curGroupSize;
+    private String chatId;
+    private Date createdAt;
+    private Date closedAt;
+    private int locationBcode;
+    private String locationAddress;
+    private String locationLongitude;
+    private String locationLatitude;
+    private String title;
+    private int pricePerUser;
+    private int type;
+    private String contents;
+    private List<PostImageDto> images;
+    private List<PostIngredientDto> ingredients;
+    private String userNickname;
+    private Long likesCount;
+}

--- a/service-user/src/main/java/com/team13/serviceuser/dto/RecipeIngredientDto.java
+++ b/service-user/src/main/java/com/team13/serviceuser/dto/RecipeIngredientDto.java
@@ -1,0 +1,9 @@
+package com.team13.serviceuser.dto;
+import lombok.Data;
+@Data
+public class RecipeIngredientDto {
+    private Long id;
+    private Long recipeId;
+    private String name;
+    private String amount;
+}

--- a/service-user/src/main/java/com/team13/serviceuser/dto/RecipeProcessDto.java
+++ b/service-user/src/main/java/com/team13/serviceuser/dto/RecipeProcessDto.java
@@ -1,0 +1,9 @@
+package com.team13.serviceuser.dto;
+import lombok.Data;
+@Data
+public class RecipeProcessDto {
+    private Long id;
+    private Long recipeId;
+    private String imagePath;
+    private String contents;
+}

--- a/service-user/src/main/java/com/team13/serviceuser/dto/RecipeResponseDto.java
+++ b/service-user/src/main/java/com/team13/serviceuser/dto/RecipeResponseDto.java
@@ -1,0 +1,26 @@
+package com.team13.serviceuser.dto;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.Date;
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+
+public class RecipeResponseDto {
+    private Long id;
+    private Long userId;
+    private String title;
+    private String contents;
+    private int commentCount;
+    private String thumbnailImagePath;
+    private Date createdAt;
+    private int type;
+    private String userNickname;
+    private List<RecipeIngredientDto> ingredients;
+    private List<RecipeProcessDto> processes;
+    private Long likesCount;
+}

--- a/service-user/src/main/java/com/team13/serviceuser/dto/UserDto.java
+++ b/service-user/src/main/java/com/team13/serviceuser/dto/UserDto.java
@@ -1,0 +1,18 @@
+package com.team13.serviceuser.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class UserDto {
+    private Long id;
+    private String email;
+    private String nickname;
+    private float userRating;
+    private String profileImageUrl;
+}

--- a/service-user/src/main/java/com/team13/serviceuser/feign/PostServiceClient.java
+++ b/service-user/src/main/java/com/team13/serviceuser/feign/PostServiceClient.java
@@ -1,6 +1,6 @@
 package com.team13.serviceuser.feign;
 
-import com.team13.serviceuser.dto.PostResponseDto;
+import com.team13.serviceuser.dto.MypagePostResponseDto;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -10,8 +10,8 @@ import java.util.List;
 @FeignClient(name = "service-post")
 public interface PostServiceClient {
     @GetMapping("/posts/user/{userId}")
-    List<PostResponseDto> getPostsByUserId(@PathVariable("userId") Long userId);
+    List<MypagePostResponseDto> getPostsByUserId(@PathVariable("userId") Long userId);
 
     @GetMapping("/posts/like/user/{userId}")
-    List<PostResponseDto> getLikePostsByUserId(@PathVariable("userId") Long userId);
+    List<MypagePostResponseDto> getLikePostsByUserId(@PathVariable("userId") Long userId);
 }

--- a/service-user/src/main/java/com/team13/serviceuser/feign/PostServiceClient.java
+++ b/service-user/src/main/java/com/team13/serviceuser/feign/PostServiceClient.java
@@ -1,0 +1,14 @@
+package com.team13.serviceuser.feign;
+
+import com.team13.serviceuser.dto.PostResponseDto;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+
+import java.util.List;
+
+@FeignClient(name = "service-post")
+public interface PostServiceClient {
+    @GetMapping("/posts/user/{userId}")
+    List<PostResponseDto> getPostsByUserId(@PathVariable("userId") Long userId);
+}

--- a/service-user/src/main/java/com/team13/serviceuser/feign/PostServiceClient.java
+++ b/service-user/src/main/java/com/team13/serviceuser/feign/PostServiceClient.java
@@ -11,4 +11,7 @@ import java.util.List;
 public interface PostServiceClient {
     @GetMapping("/posts/user/{userId}")
     List<PostResponseDto> getPostsByUserId(@PathVariable("userId") Long userId);
+
+    @GetMapping("/posts/like/user/{userId}")
+    List<PostResponseDto> getLikePostsByUserId(@PathVariable("userId") Long userId);
 }

--- a/service-user/src/main/java/com/team13/serviceuser/feign/RecipeServiceClient.java
+++ b/service-user/src/main/java/com/team13/serviceuser/feign/RecipeServiceClient.java
@@ -1,5 +1,6 @@
 package com.team13.serviceuser.feign;
 
+import com.team13.serviceuser.dto.PostResponseDto;
 import com.team13.serviceuser.dto.RecipeResponseDto;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -12,4 +13,7 @@ public interface RecipeServiceClient {
 
     @GetMapping("/recipes/user/{userId}")
     List<RecipeResponseDto> getRecipesByUserId(@PathVariable("userId") Long userId);
+
+    @GetMapping("/recipes/like/user/{userId}")
+    List<RecipeResponseDto> getLikeRecipesByUserId(@PathVariable("userId") Long userId);
 }

--- a/service-user/src/main/java/com/team13/serviceuser/feign/RecipeServiceClient.java
+++ b/service-user/src/main/java/com/team13/serviceuser/feign/RecipeServiceClient.java
@@ -1,0 +1,15 @@
+package com.team13.serviceuser.feign;
+
+import com.team13.serviceuser.dto.RecipeResponseDto;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+
+import java.util.List;
+
+@FeignClient(name = "service-recipe")
+public interface RecipeServiceClient {
+
+    @GetMapping("/recipes/user/{userId}")
+    List<RecipeResponseDto> getRecipesByUserId(@PathVariable("userId") Long userId);
+}

--- a/service-user/src/main/java/com/team13/serviceuser/feign/RecipeServiceClient.java
+++ b/service-user/src/main/java/com/team13/serviceuser/feign/RecipeServiceClient.java
@@ -1,7 +1,6 @@
 package com.team13.serviceuser.feign;
 
-import com.team13.serviceuser.dto.PostResponseDto;
-import com.team13.serviceuser.dto.RecipeResponseDto;
+import com.team13.serviceuser.dto.MypageRecipeResponseDto;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -12,8 +11,8 @@ import java.util.List;
 public interface RecipeServiceClient {
 
     @GetMapping("/recipes/user/{userId}")
-    List<RecipeResponseDto> getRecipesByUserId(@PathVariable("userId") Long userId);
+    List<MypageRecipeResponseDto> getRecipesByUserId(@PathVariable("userId") Long userId);
 
     @GetMapping("/recipes/like/user/{userId}")
-    List<RecipeResponseDto> getLikeRecipesByUserId(@PathVariable("userId") Long userId);
+    List<MypageRecipeResponseDto> getLikeRecipesByUserId(@PathVariable("userId") Long userId);
 }

--- a/service-user/src/main/java/com/team13/serviceuser/service/MyPageService.java
+++ b/service-user/src/main/java/com/team13/serviceuser/service/MyPageService.java
@@ -1,0 +1,22 @@
+package com.team13.serviceuser.service;
+
+import com.team13.serviceuser.dto.PostResponseDto;
+import com.team13.serviceuser.feign.PostServiceClient;
+import com.team13.serviceuser.repository.UserRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class MyPageService {
+    
+    @Autowired
+    private PostServiceClient postServiceClient;
+
+    public List<PostResponseDto> getPostsByUserId(Long userId) {
+        return postServiceClient.getPostsByUserId(userId);
+    }
+
+
+}

--- a/service-user/src/main/java/com/team13/serviceuser/service/MyPageService.java
+++ b/service-user/src/main/java/com/team13/serviceuser/service/MyPageService.java
@@ -1,6 +1,8 @@
 package com.team13.serviceuser.service;
 
 import com.team13.serviceuser.dto.PostResponseDto;
+import com.team13.serviceuser.dto.UserDto;
+import com.team13.serviceuser.entity.User;
 import com.team13.serviceuser.feign.PostServiceClient;
 import com.team13.serviceuser.repository.UserRepository;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -10,12 +12,31 @@ import java.util.List;
 
 @Service
 public class MyPageService {
-    
+   
+    @Autowired
+    private UserRepository userRepository;
+
     @Autowired
     private PostServiceClient postServiceClient;
 
     public List<PostResponseDto> getPostsByUserId(Long userId) {
         return postServiceClient.getPostsByUserId(userId);
+    }
+
+    public UserDto getUserById(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("User not found with id: " + userId));
+        return convertToDto(user);
+    }
+
+    private UserDto convertToDto(User user) {
+        return UserDto.builder()
+                .id(user.getId())
+                .email(user.getEmail())
+                .nickname(user.getNickname())
+                .userRating(user.getUserRating())
+                .profileImageUrl(user.getProfileImageUrl())
+                .build();
     }
 
 

--- a/service-user/src/main/java/com/team13/serviceuser/service/MyPageService.java
+++ b/service-user/src/main/java/com/team13/serviceuser/service/MyPageService.java
@@ -15,11 +15,11 @@ public class MyPageService {
 
     @Autowired
     private UserRepository userRepository;
-
     @Autowired
     private PostServiceClient postServiceClient;
     @Autowired
     private RecipeServiceClient recipeServiceClient;
+
     public List<MypagePostResponseDto> getPostsByUserId(Long userId) {
         return postServiceClient.getPostsByUserId(userId);
     }
@@ -37,6 +37,24 @@ public class MyPageService {
     public UserDto getUserById(Long userId) {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new IllegalArgumentException("User not found with id: " + userId));
+        return convertToDto(user);
+    }
+
+    // 사용자 정보 업데이트 메서드
+    public UserDto updateUser(Long userId, UserDto userDto) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("User not found with id: " + userId));
+
+        // 업데이트할 사용자 정보 설정
+        user.setEmail(userDto.getEmail());
+        user.setNickname(userDto.getNickname());
+        user.setUserRating(userDto.getUserRating());
+        user.setProfileImageUrl(userDto.getProfileImageUrl());
+        // 비밀번호는 업데이트하는 로직에 따라 처리 필요 (예: 암호화된 상태로 저장)
+
+        // 변경된 사용자 정보 저장
+        userRepository.save(user);
+
         return convertToDto(user);
     }
 

--- a/service-user/src/main/java/com/team13/serviceuser/service/MyPageService.java
+++ b/service-user/src/main/java/com/team13/serviceuser/service/MyPageService.java
@@ -28,7 +28,9 @@ public class MyPageService {
     public List<RecipeResponseDto> getRecipesByUserId(Long userId) {
         return recipeServiceClient.getRecipesByUserId(userId);
     }
-
+    public List<PostResponseDto> getLikePostsByUserId(Long userId) {
+        return postServiceClient.getLikePostsByUserId(userId);
+    }
 
     public UserDto getUserById(Long userId) {
         User user = userRepository.findById(userId)

--- a/service-user/src/main/java/com/team13/serviceuser/service/MyPageService.java
+++ b/service-user/src/main/java/com/team13/serviceuser/service/MyPageService.java
@@ -1,8 +1,6 @@
 package com.team13.serviceuser.service;
 
-import com.team13.serviceuser.dto.PostResponseDto;
-import com.team13.serviceuser.dto.RecipeResponseDto;
-import com.team13.serviceuser.dto.UserDto;
+import com.team13.serviceuser.dto.*;
 import com.team13.serviceuser.entity.User;
 import com.team13.serviceuser.feign.PostServiceClient;
 import com.team13.serviceuser.feign.RecipeServiceClient;
@@ -22,17 +20,17 @@ public class MyPageService {
     private PostServiceClient postServiceClient;
     @Autowired
     private RecipeServiceClient recipeServiceClient;
-    public List<PostResponseDto> getPostsByUserId(Long userId) {
+    public List<MypagePostResponseDto> getPostsByUserId(Long userId) {
         return postServiceClient.getPostsByUserId(userId);
     }
-    public List<RecipeResponseDto> getRecipesByUserId(Long userId) {
+    public List<MypageRecipeResponseDto> getRecipesByUserId(Long userId) {
         return recipeServiceClient.getRecipesByUserId(userId);
     }
-    public List<PostResponseDto> getLikePostsByUserId(Long userId) {
+    public List<MypagePostResponseDto> getLikePostsByUserId(Long userId) {
         return postServiceClient.getLikePostsByUserId(userId);
     }
 
-    public List<RecipeResponseDto> getLikeRecipesByUserId(Long userId) {
+    public List<MypageRecipeResponseDto> getLikeRecipesByUserId(Long userId) {
         return recipeServiceClient.getLikeRecipesByUserId(userId);
     }
 

--- a/service-user/src/main/java/com/team13/serviceuser/service/MyPageService.java
+++ b/service-user/src/main/java/com/team13/serviceuser/service/MyPageService.java
@@ -32,6 +32,10 @@ public class MyPageService {
         return postServiceClient.getLikePostsByUserId(userId);
     }
 
+    public List<RecipeResponseDto> getLikeRecipesByUserId(Long userId) {
+        return recipeServiceClient.getLikeRecipesByUserId(userId);
+    }
+
     public UserDto getUserById(Long userId) {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new IllegalArgumentException("User not found with id: " + userId));

--- a/service-user/src/main/java/com/team13/serviceuser/service/MyPageService.java
+++ b/service-user/src/main/java/com/team13/serviceuser/service/MyPageService.java
@@ -1,9 +1,11 @@
 package com.team13.serviceuser.service;
 
 import com.team13.serviceuser.dto.PostResponseDto;
+import com.team13.serviceuser.dto.RecipeResponseDto;
 import com.team13.serviceuser.dto.UserDto;
 import com.team13.serviceuser.entity.User;
 import com.team13.serviceuser.feign.PostServiceClient;
+import com.team13.serviceuser.feign.RecipeServiceClient;
 import com.team13.serviceuser.repository.UserRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -12,16 +14,21 @@ import java.util.List;
 
 @Service
 public class MyPageService {
-   
+
     @Autowired
     private UserRepository userRepository;
 
     @Autowired
     private PostServiceClient postServiceClient;
-
+    @Autowired
+    private RecipeServiceClient recipeServiceClient;
     public List<PostResponseDto> getPostsByUserId(Long userId) {
         return postServiceClient.getPostsByUserId(userId);
     }
+    public List<RecipeResponseDto> getRecipesByUserId(Long userId) {
+        return recipeServiceClient.getRecipesByUserId(userId);
+    }
+
 
     public UserDto getUserById(Long userId) {
         User user = userRepository.findById(userId)

--- a/service-user/src/main/java/com/team13/serviceuser/util/RandomUserGenerator.java
+++ b/service-user/src/main/java/com/team13/serviceuser/util/RandomUserGenerator.java
@@ -1,0 +1,89 @@
+package com.team13.serviceuser.util;
+
+import com.team13.serviceuser.dto.UserDto;
+
+import java.util.List;
+import java.util.Random;
+
+public class RandomUserGenerator {
+
+    private static final Random random = new Random();
+
+    // 임의의 이메일 도메인 목록
+    private static final List<String> EMAIL_DOMAINS = List.of(
+            "@gamil.com", "@naver.com", "@daum.net", "@kakao.com"
+    );
+
+    // 임의의 닉네임을 위한 형용사와 명사 목록
+    private static final List<String> ADJECTIVES = List.of(
+            "친절한", "사교적인", "성실한", "정직한", "용감한", "활발한", "책임감 있는", "인내심 있는", "겸손한", "유머러스한"
+    );
+
+    private static final List<String> NOUNS = List.of(
+            "고래", "호랑이", "사자", "토끼", "부엉이", "여우", "늑대", "펭귄", "곰", "도마뱀"
+    );
+
+    // 임의의 프로필 이미지 URL 목록
+    private static final List<String> PROFILE_IMAGE_URLS = List.of(
+            "https://example.com/images/profile1.jpg",
+            "https://example.com/images/profile2.jpg",
+            "https://example.com/images/profile3.jpg",
+            "https://example.com/images/profile4.jpg"
+    );
+
+    public static String generateEmailId() {
+        int length = 5;
+        String characters = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+        StringBuilder chatIdBuilder = new StringBuilder(length);
+
+        for (int i = 0; i < length; i++) {
+            int index = random.nextInt(characters.length());
+            chatIdBuilder.append(characters.charAt(index));
+        }
+
+        return chatIdBuilder.toString();
+    }
+
+
+    // 임의의 사용자 ID 생성
+    public static Long generateId() {
+        return (long) (random.nextInt(10) + 1);
+    }
+
+
+
+    // 임의의 이메일 생성
+    public static String generateEmail(String emailId) {
+        String domain = EMAIL_DOMAINS.get(random.nextInt(EMAIL_DOMAINS.size()));
+        return emailId + domain;
+    }
+
+    // 임의의 닉네임 생성
+    public static String generateNickname() {
+        String adjective = ADJECTIVES.get(random.nextInt(ADJECTIVES.size()));
+        String noun = NOUNS.get(random.nextInt(NOUNS.size()));
+        return adjective + " " + noun;
+    }
+
+    // 임의의 사용자 평점 생성
+    public static float generateUserRating() {
+        return 1.0f + random.nextFloat() * 4.0f; // 1.0 ~ 5.0 사이의 평점
+    }
+
+    // 임의의 프로필 이미지 URL 생성
+    public static String generateProfileImageUrl() {
+        return PROFILE_IMAGE_URLS.get(random.nextInt(PROFILE_IMAGE_URLS.size()));
+    }
+
+    // 임의의 UserDto 객체 생성
+    public static UserDto generateRandomUser() {
+        String nickname = generateNickname();
+        return UserDto.builder()
+                .id(generateId())
+                .email(generateEmail(nickname))
+                .nickname(nickname)
+                .userRating(generateUserRating())
+                .profileImageUrl(generateProfileImageUrl())
+                .build();
+    }
+}


### PR DESCRIPTION
## Type
기능 추가 
마이페이지 기능으로 
본인이 작성한 레시피, 공동구매 게시글 확인 할 수 있고
본인이 좋아요 누른 레시피, 공동구매 게시글을 확인 할 수 있고
본인 정보를 확인하고 수정할 수 있습니다.
## Description
userNickname가져왔던 것 처럼 Post와 Recipe에 대한 feign을 Service-user에다가 넣어서 해당 값들 통신으로 진행했습니다.
이과정에서 MypageDto를 따로 두어서 이후 화면 수정에 따른 api명세서 변경을 반영할 계획입니다.
비밀번호 수정은 보안 관련 로직이 필요할 것 같아서 제외하고 일단 구현했습니다.
예시 api의 경우 레시피, 공동구매 게시글 리스트는 홈화면에서 사용한 것과 동일한 것 같아서
user정보에 대한 예시 api만 작성했습니다. 