### PR TITLE
feat: 채팅방 리스트 API에서 각 채팅방의 정보를 함께 전송

### DIFF
--- a/server-gateway/src/main/java/com/team13/servergateway/util/RouterValidator.java
+++ b/server-gateway/src/main/java/com/team13/servergateway/util/RouterValidator.java
@@ -13,11 +13,14 @@ public class RouterValidator {
             List.of("GET", "/user/config"),
             List.of("GET", "/mypage"),
             List.of("GET", "/users"),
+            // NOTE: 레시피 서비스
             List.of("POST", "/recipes"),
-            List.of("GET", "/recipes")
-            // 채팅 관련 API는 모두 토큰 요구
-//            List.of("GET", "/chat"),
-//            List.of("POST", "/chat")
+            List.of("GET", "/recipes"),
+            // NOTE: 채팅 서비스
+            List.of("GET", "/chatroom"),
+            List.of("GET", "/chatroom/list"),
+            List.of("POST", "/chatroom"),
+            List.of("POST", "/chatroom/join")
     );
 
     // 만약 request의 path가 securedApiEndpoints 중 하나인 경우 true를 반환하고, 그렇지 않으면 false를 반환함

--- a/service-chat/src/main/java/com/team13/servicechat/controller/IndexController.java
+++ b/service-chat/src/main/java/com/team13/servicechat/controller/IndexController.java
@@ -2,7 +2,6 @@ package com.team13.servicechat.controller;
 
 import com.team13.servicechat.dto.ChatroomDto;
 import com.team13.servicechat.dto.JwtPayloadDto;
-import com.team13.servicechat.entity.Chatroom;
 import com.team13.servicechat.feign.UserFeignClient;
 import com.team13.servicechat.service.ChatroomService;
 import com.team13.servicechat.service.JwtService;
@@ -66,11 +65,8 @@ public class IndexController {
 
     // 사용자가 속한 채팅방 리스트 반환
     @GetMapping("/chatroom/list")
-    public List<ChatroomDto> getChatroomList(@CookieValue("LTK") String loginToken) {
-
-        JwtPayloadDto payload = jwtService.getPayloadFromToken(loginToken);
-
-        return chatroomService.getChatroomList(Long.parseLong(payload.getUserId()));
+    public List<ChatroomDto> getChatroomList(@RequestHeader("X-User-Id") String userId) {
+        return chatroomService.getChatroomList(Long.parseLong(userId));
     }
 
 

--- a/service-chat/src/main/java/com/team13/servicechat/dto/ChatroomDto.java
+++ b/service-chat/src/main/java/com/team13/servicechat/dto/ChatroomDto.java
@@ -1,5 +1,6 @@
 package com.team13.servicechat.dto;
 
+import com.team13.servicechat.entity.ChatMessage;
 import lombok.Builder;
 import lombok.Data;
 
@@ -12,6 +13,7 @@ public class ChatroomDto {
     private Long postId;
     private List<Long> userIds;
     private List<ChatMessageDto> messages;
-    private String lastMessage;
     private Integer unreadMsgsCounter;
+    private ChatMessage lastMessage;
+    private PostInfoDTO post;
 }

--- a/service-chat/src/main/java/com/team13/servicechat/dto/PostInfoDTO.java
+++ b/service-chat/src/main/java/com/team13/servicechat/dto/PostInfoDTO.java
@@ -1,0 +1,11 @@
+package com.team13.servicechat.dto;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class PostInfoDTO {
+    private String title;
+    private String imagePath;
+}

--- a/service-chat/src/main/java/com/team13/servicechat/dto/feign/PostDTO.java
+++ b/service-chat/src/main/java/com/team13/servicechat/dto/feign/PostDTO.java
@@ -1,0 +1,31 @@
+package com.team13.servicechat.dto.feign;
+
+import lombok.Builder;
+import lombok.Data;
+
+import java.util.Date;
+import java.util.List;
+
+@Data
+@Builder
+public class PostDTO {
+    private Long id;
+    private int status;  // 0 - 마감, 1 - 진행중
+    private String userNickname;
+    private int groupSize;
+    private int curGroupSize;
+    private String chatId;
+    private Date createdAt;
+    private Date closedAt;
+    private int locationBcode;
+    private String locationAddress;
+    private String locationLongitude;
+    private String locationLatitude;
+    private String title;
+    private int pricePerUser;
+    private int type;
+    private String contents;
+    private List<PostIngredientDTO> ingredients;
+    private List<PostImageDTO> images;
+    private Long likesCount;
+}

--- a/service-chat/src/main/java/com/team13/servicechat/dto/feign/PostImageDTO.java
+++ b/service-chat/src/main/java/com/team13/servicechat/dto/feign/PostImageDTO.java
@@ -1,0 +1,15 @@
+package com.team13.servicechat.dto.feign;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PostImageDTO {
+    private Long id;
+    private String imagePath;
+}

--- a/service-chat/src/main/java/com/team13/servicechat/dto/feign/PostIngredientDTO.java
+++ b/service-chat/src/main/java/com/team13/servicechat/dto/feign/PostIngredientDTO.java
@@ -1,0 +1,16 @@
+package com.team13.servicechat.dto.feign;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PostIngredientDTO {
+    private Long id;
+    private String name;
+    private String url;
+}

--- a/service-chat/src/main/java/com/team13/servicechat/feign/PostServiceClient.java
+++ b/service-chat/src/main/java/com/team13/servicechat/feign/PostServiceClient.java
@@ -1,0 +1,12 @@
+package com.team13.servicechat.feign;
+
+import com.team13.servicechat.dto.feign.PostDTO;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+
+@FeignClient(name = "service-post")
+public interface PostServiceClient {
+    @GetMapping("/{id}")
+    PostDTO getPostById(@PathVariable("id") Long id);
+}

--- a/service-chat/src/main/java/com/team13/servicechat/service/ChatroomService.java
+++ b/service-chat/src/main/java/com/team13/servicechat/service/ChatroomService.java
@@ -2,23 +2,32 @@ package com.team13.servicechat.service;
 
 import com.team13.servicechat.dto.ChatMessageDto;
 import com.team13.servicechat.dto.ChatroomDto;
+import com.team13.servicechat.dto.PostInfoDTO;
+import com.team13.servicechat.dto.feign.PostDTO;
 import com.team13.servicechat.entity.ChatMessage;
 import com.team13.servicechat.entity.Chatroom;
 import com.team13.servicechat.entity.UserJoinedChats;
+import com.team13.servicechat.feign.PostServiceClient;
 import com.team13.servicechat.repository.ChatMessageRepository;
 import com.team13.servicechat.repository.ChatroomRepository;
 import com.team13.servicechat.repository.UserJoinedChatsRepository;
+import feign.FeignException;
 import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
 import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
+@Log4j2
 @Service
 @RequiredArgsConstructor
 public class ChatroomService {
+
+    // NOTE: service-post에 연결하기 위한 Feign 갹채
+    private final PostServiceClient postServiceClient;
 
     // 채팅방 메시지 데이터를 저장하는 레포지토리
     private final ChatroomRepository chatroomRepository;
@@ -39,7 +48,7 @@ public class ChatroomService {
         if (!chatroomRepository.existsById("test-chatroom")) {
             chatroomRepository.save(Chatroom.builder()
                             .id("test-chatroom")
-                            .postId(-1)
+                            .postId(1)
                             .messageIds(new ArrayList<>())
                             .userIds(new ArrayList<>())
                             .build());
@@ -182,8 +191,6 @@ public class ChatroomService {
 
         Optional<UserJoinedChats> userJoinedChats = userJoinedChatsRepository.findById(userId);
 
-        System.out.println(userJoinedChats);
-
         // 사용자가 참여한 채팅방이 존재하는 경우에만 결과 반환
         if (userJoinedChats.isPresent()) {
             List<ChatroomDto> chatroomDtos = new ArrayList<>();
@@ -198,12 +205,36 @@ public class ChatroomService {
                 List<ChatMessage> unreadMessages = userUnreadMsgsService.getUnreadMsgsInChatroom(userId, chatroomId);
 
                 // 존재하는 채팅방인 경우에만 chatroomDtos에 추가
-                opChatroom.ifPresent(chatroom -> chatroomDtos.add(ChatroomDto.builder()
+                if (opChatroom.isPresent()) {
+                    // NOTE: 채팅방에 연결된 게시글이 없을 경우를 대비한 try문
+                    try {
+                        // NOTE: 해당 채팅방의 게시글 정보를 가져옴
+                        PostDTO post = postServiceClient.getPostById(opChatroom.get().getPostId());
+
+                        // NOTE: 게시글 정보를 담는 DTO 생성
+                        PostInfoDTO postInfo = PostInfoDTO.builder()
+                                .title(post.getTitle())
+                                .imagePath(post.getImages().isEmpty() ? "" : post.getImages().get(0).getImagePath())
+                                .build();
+
+                        // NOTE: 마지막 채팅 메시지 정보 가져오기
+                        List<Long> messages = opChatroom.get().getMessageIds();
+                        Long lastMsgId = messages.get(messages.size() - 1);
+
+                        Optional<ChatMessage> lastMsg = getMessageById(lastMsgId);
+
+                        // NOTE: 채팅방 정보 추가
+                        opChatroom.ifPresent(chatroom -> chatroomDtos.add(ChatroomDto.builder()
                                 .id(chatroom.getId())
                                 .postId(chatroom.getPostId())
                                 .unreadMsgsCounter(unreadMessages.size())
-                                .lastMessage(chatroom.getLastMessage())
+                                .lastMessage(lastMsg.orElse(null))
+                                .post(postInfo)
                                 .build()));
+                    } catch (FeignException e) {
+                        log.error("Couldn't find post!", e);
+                    }
+                }
             }
 
             return chatroomDtos;

--- a/service-chat/src/main/java/com/team13/servicechat/service/ChatroomService.java
+++ b/service-chat/src/main/java/com/team13/servicechat/service/ChatroomService.java
@@ -39,20 +39,10 @@ public class ChatroomService {
         if (!chatroomRepository.existsById("test-chatroom")) {
             chatroomRepository.save(Chatroom.builder()
                             .id("test-chatroom")
-                            .postId(1)
+                            .postId(-1)
                             .messageIds(new ArrayList<>())
-                            .userIds(new ArrayList<>(List.of(1L, 2L)))
+                            .userIds(new ArrayList<>())
                             .build());
-
-            userJoinedChatsRepository.save(UserJoinedChats.builder()
-                            .id(1L)
-                            .chatroomIds(List.of("test-chatroom"))
-                            .build());
-
-            userJoinedChatsRepository.save(UserJoinedChats.builder()
-                    .id(2L)
-                    .chatroomIds(List.of("test-chatroom"))
-                    .build());
         }
     }
 
@@ -191,6 +181,8 @@ public class ChatroomService {
     public List<ChatroomDto> getChatroomList(Long userId) {
 
         Optional<UserJoinedChats> userJoinedChats = userJoinedChatsRepository.findById(userId);
+
+        System.out.println(userJoinedChats);
 
         // 사용자가 참여한 채팅방이 존재하는 경우에만 결과 반환
         if (userJoinedChats.isPresent()) {

--- a/service-user/src/main/java/com/team13/serviceuser/feign/ChatServiceClient.java
+++ b/service-user/src/main/java/com/team13/serviceuser/feign/ChatServiceClient.java
@@ -1,0 +1,13 @@
+package com.team13.serviceuser.feign;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+import java.util.Map;
+
+@FeignClient(name = "service-chat")
+public interface ChatServiceClient {
+    @PostMapping("/chatroom/join")
+    String joinChatroom(@RequestBody Map<String, String> request);
+}

--- a/service-user/src/main/java/com/team13/serviceuser/service/SignUpService.java
+++ b/service-user/src/main/java/com/team13/serviceuser/service/SignUpService.java
@@ -2,11 +2,17 @@ package com.team13.serviceuser.service;
 
 import com.team13.serviceuser.converter.SignConverter;
 import com.team13.serviceuser.dto.SignRequest;
+import com.team13.serviceuser.entity.User;
+import com.team13.serviceuser.feign.ChatServiceClient;
 import com.team13.serviceuser.repository.UserRepository;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
+
+import java.util.HashMap;
+import java.util.Map;
 
 @Service
 @Transactional
@@ -15,6 +21,9 @@ public class SignUpService {
 
     private final UserRepository userRepository;
     private final BCryptPasswordEncoder encoder;
+
+    @Autowired
+    private ChatServiceClient chatServiceClient;
 
     public boolean checkEmailDuplicate(String email) {
         return userRepository.existsByEmail(email);
@@ -28,6 +37,12 @@ public class SignUpService {
     //비밀번호 암호화
 
     public void registerUser(SignRequest.RegisterRequestDto registerRequestDto) {
-        userRepository.save(SignConverter.toUserEntity(registerRequestDto, encoder.encode(registerRequestDto.getPassword())));
+        User savedUser = userRepository.save(SignConverter.toUserEntity(registerRequestDto, encoder.encode(registerRequestDto.getPassword())));
+
+        // TOOD: 개발 단계에서 모든 유저는 테스트 채팅방에 초대함 (추후 테스트 완료시 아래 코드 제거)
+        Map<String, String> requestBody = new HashMap<>();
+        requestBody.put("chatroomId", "test-chatroom");
+        requestBody.put("userId", savedUser.getId().toString());
+        chatServiceClient.joinChatroom(requestBody);
     }
 }


### PR DESCRIPTION
## Type
기능 추가

## Description
* 회원가입 시 자동으로 테스트 채팅방으로 초대함 (해당 부분은 추후 테스트 완료 시 제거할 예정)
* 채팅방 리스트 API에서 각 채팅방의 게시글 정보(게시글 이름 및 이미지, 마지막 메시지 정보)를 함께 전송함