### PR TITLE
[마이페이지,레시피] equal gateway적용

### DIFF
--- a/server-gateway/src/main/java/com/team13/servergateway/util/RouterValidator.java
+++ b/server-gateway/src/main/java/com/team13/servergateway/util/RouterValidator.java
@@ -11,11 +11,15 @@ public class RouterValidator {
     // 로그인 토큰이 요구되는 path
     private final List<List<String>> securedApiEndpoints = List.of(
             // NOTE: 유저 서비스
-            List.of("GET", "/api2/user/mypage"),
+            List.of("GET", "/api2/user/mypage/info"),
+            List.of("GET", "/api2/user/mypage/recipes"),
+            List.of("GET", "/api2/user/mypage/likeRecipes"),
             List.of("GET", "/api2/user/users"),
             // NOTE: 레시피 서비스
             List.of("POST", "/api2/recipe/recipes"),
             List.of("GET", "/api2/recipe/recipes"),
+            List.of("POST", "/api2/recipe/recipes/like"), //동적 처리 {recipeId} 인식 위해서
+            List.of("GET", "/api2/recipe/recipes/like"),
             // NOTE: 채팅 서비스
             List.of("GET", "/api2/chat/chatroom"),
             List.of("GET", "/api2/chat/chatroom/list"),
@@ -25,9 +29,13 @@ public class RouterValidator {
 
     // 만약 request의 path가 securedApiEndpoints 중 하나인 경우 true를 반환하고, 그렇지 않으면 false를 반환함
     public boolean isSecured(ServerHttpRequest request) {
+        String path = request.getURI().getPath();
         return securedApiEndpoints.stream().anyMatch(methodAndPath ->
                 request.getMethod().toString().equals(methodAndPath.get(0)) &&
-                        request.getURI().getPath().equals(methodAndPath.get(1))
+                        (
+                                path.equals(methodAndPath.get(1)) ||
+                                (path.startsWith("/api2/recipe/recipes/like/") && methodAndPath.get(1).equals("/api2/recipe/recipes/like"))
+                        )
         );
     }
 }

--- a/service-recipe/src/main/java/com/team13/servicerecipe/controller/RecipeController.java
+++ b/service-recipe/src/main/java/com/team13/servicerecipe/controller/RecipeController.java
@@ -52,7 +52,7 @@ public class RecipeController {
         }
     }
 
-    @PostMapping("/{recipeId}/like")
+    @PostMapping("/like/{recipeId}")
     public ResponseEntity<String> toggleLikeRecipe(@PathVariable("recipeId") Long recipeId, HttpServletRequest request) {
         String userIdHeader = request.getHeader("X-User-Id");
 
@@ -73,7 +73,7 @@ public class RecipeController {
     }
 
     //단순 확인용 나중에 지울예정 postResponseDto에서 좋아요수까지 확인가능
-    @GetMapping("/{recipeId}/likes")
+    @GetMapping("/like/{recipeId}")
     public ResponseEntity<Long> getLikesCount(@PathVariable("recipeId") Long recipeId) {
         Long likesCount = likeRecipeService.getLikesCount(recipeId);
         return ResponseEntity.ok(likesCount);


### PR DESCRIPTION
## Type
코드 리팩토링

## Description
변경 사항 혹은 수정사항을 간단하게 작성해주세요.
gateway경로가 equal로 변경되면서 매칭되도록 수정했습니다
recipeLike post의 경우 equal로 할 경우 {recipeId}가 인식이 되지 않아서 동적처리로 변경했습니다