### PR TITLE
ref: RouterValidator의 URL를 탐지할 때 정규표현식을 사용하도록 리팩토링

### DIFF
--- a/server-gateway/src/main/java/com/team13/servergateway/util/RouterValidator.java
+++ b/server-gateway/src/main/java/com/team13/servergateway/util/RouterValidator.java
@@ -4,46 +4,47 @@ import org.springframework.http.server.reactive.ServerHttpRequest;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
+import java.util.regex.Pattern;
 
 @Component
 public class RouterValidator {
 
     // 로그인 토큰이 요구되는 path
-    private final List<List<String>> securedApiEndpoints = List.of(
+    private final List<List<Pattern>> securedApiEndpoints = List.of(
             // NOTE: 유저 서비스
-            List.of("GET", "/api2/user/mypage/info"),
-            List.of("GET", "/api2/user/mypage/recipes"),
-            List.of("GET", "/api2/user/mypage/likeRecipes"),
-            List.of("GET", "/api2/user/users"),
-            List.of("GET", "/api2/user/mypage/posts"),
-            List.of("GET", "/api2/user/mypage/likePosts"),
+            List.of(Pattern.compile("GET"), Pattern.compile("^/api2/user/mypage/info$")),
+            List.of(Pattern.compile("GET"), Pattern.compile("^/api2/user/mypage/recipes$")),
+            List.of(Pattern.compile("GET"), Pattern.compile("^/api2/user/mypage/likeRecipes$")),
+            List.of(Pattern.compile("GET"), Pattern.compile("^/api2/user/users$")),
+            List.of(Pattern.compile("GET"), Pattern.compile("^/api2/user/mypage/posts$")),
+            List.of(Pattern.compile("GET"), Pattern.compile("^/api2/user/mypage/likePosts$")),
             // NOTE: 레시피 서비스
-            List.of("POST", "/api2/recipe/recipes"),
-            List.of("GET", "/api2/recipe/recipes"),
-            List.of("POST", "/api2/recipe/recipes/like"), //동적 처리 {Id} 인식 위해서
-            List.of("GET", "/api2/recipe/recipes/like"),
+            List.of(Pattern.compile("GET"), Pattern.compile("^/api2/recipe/recipes$")),
+            List.of(Pattern.compile("POST"), Pattern.compile("^/api2/recipe/recipes$")),
+            List.of(Pattern.compile("GET"), Pattern.compile("^/api2/recipe/recipes/like/")),
+            List.of(Pattern.compile("POST"), Pattern.compile("^/api2/recipe/recipes/like/")),
+            List.of(Pattern.compile("GET"), Pattern.compile("^/api2/recipe/comments/")),
+            List.of(Pattern.compile("POST"), Pattern.compile("^/api2/recipe/comments/")),
+            List.of(Pattern.compile("GET"), Pattern.compile("^/api2/recipe/comments/replies$")),
+            List.of(Pattern.compile("GET"), Pattern.compile("^/api2/recipe/comments/user$")),
             // NOTE: 채팅 서비스
-            List.of("GET", "/api2/chat/chatroom"),
-            List.of("GET", "/api2/chat/chatroom/list"),
-            List.of("POST", "/api2/chat/chatroom"),
-            List.of("POST", "/api2/chat/chatroom/join"),
+            List.of(Pattern.compile("GET"), Pattern.compile("^/api2/chat/chatroom$")),
+            List.of(Pattern.compile("POST"), Pattern.compile("^/api2/chat/chatroom$")),
+            List.of(Pattern.compile("GET"), Pattern.compile("^/api2/chat/chatroom/list$")),
+            List.of(Pattern.compile("POST"), Pattern.compile("^/api2/chat/chatroom/join$")),
             // NOTE: 공동구매 서비스
-            List.of("POST", "/api2/post/posts"),
-            List.of("GET", "/api2/post/posts"),
-            List.of("POST", "/api2/post/posts/like"), //동적 처리 {postId} 인식 위해서
-            List.of("GET", "/api2/post/posts/like")
+            List.of(Pattern.compile("GET"), Pattern.compile("^/api2/post/posts$")),
+            List.of(Pattern.compile("POST"), Pattern.compile("^/api2/post/posts$")),
+            List.of(Pattern.compile("GET"), Pattern.compile("^/api2/post/posts/like/")),
+            List.of(Pattern.compile("POST"), Pattern.compile("^/api2/post/posts/like/"))
     );
 
     // 만약 request의 path가 securedApiEndpoints 중 하나인 경우 true를 반환하고, 그렇지 않으면 false를 반환함
     public boolean isSecured(ServerHttpRequest request) {
+        String method = request.getMethod().toString();
         String path = request.getURI().getPath();
+
         return securedApiEndpoints.stream().anyMatch(methodAndPath ->
-                request.getMethod().toString().equals(methodAndPath.get(0)) &&
-                        (
-                                path.equals(methodAndPath.get(1))
-                                        || (path.startsWith("/api2/recipe/recipes/like/") && methodAndPath.get(1).equals("/api2/recipe/recipes/like"))
-                                        ||(path.startsWith("/api2/post/posts/like/") && methodAndPath.get(1).equals("/api2/post/posts/like"))
-                        )
-        );
+                methodAndPath.get(0).matcher(method).matches() && methodAndPath.get(1).matcher(path).matches());
     }
 }

--- a/server-gateway/src/main/java/com/team13/servergateway/util/RouterValidator.java
+++ b/server-gateway/src/main/java/com/team13/servergateway/util/RouterValidator.java
@@ -22,9 +22,9 @@ public class RouterValidator {
             List.of(Pattern.compile("GET"), Pattern.compile("^/api2/recipe/recipes$")),
             List.of(Pattern.compile("POST"), Pattern.compile("^/api2/recipe/recipes$")),
             List.of(Pattern.compile("GET"), Pattern.compile("^/api2/recipe/recipes/like/")),
-            List.of(Pattern.compile("POST"), Pattern.compile("^/api2/recipe/recipes/like/")),
+            List.of(Pattern.compile("POST"), Pattern.compile("^/api2/recipe/recipes/like/\\d+$")),
             List.of(Pattern.compile("GET"), Pattern.compile("^/api2/recipe/comments/")),
-            List.of(Pattern.compile("POST"), Pattern.compile("^/api2/recipe/comments/")),
+            List.of(Pattern.compile("POST"), Pattern.compile("^/api2/recipe/comments/\\d+$")),
             List.of(Pattern.compile("GET"), Pattern.compile("^/api2/recipe/comments/replies$")),
             List.of(Pattern.compile("GET"), Pattern.compile("^/api2/recipe/comments/user$")),
             // NOTE: 채팅 서비스


### PR DESCRIPTION
## Type
코드 리팩토링

## Description
`RouterValidator` 클래스 내에서 URL을 탐지하는 로직을 정규표현식을 사용하도록 리팩토링을 진행하였습니다.
