### PR TITLE
[로그인] 서버 쿠키 도메인 변경

### DIFF
--- a/server-gateway/src/main/java/com/team13/servergateway/util/RouterValidator.java
+++ b/server-gateway/src/main/java/com/team13/servergateway/util/RouterValidator.java
@@ -36,7 +36,7 @@ public class RouterValidator {
             List.of(Pattern.compile("GET"), Pattern.compile("^/api2/post/posts$")),
             List.of(Pattern.compile("POST"), Pattern.compile("^/api2/post/posts$")),
             List.of(Pattern.compile("GET"), Pattern.compile("^/api2/post/posts/like/")),
-            List.of(Pattern.compile("POST"), Pattern.compile("^/api2/post/posts/like/"))
+            List.of(Pattern.compile("POST"), Pattern.compile("^/api2/post/posts/like/\\d+$"))
     );
 
     // 만약 request의 path가 securedApiEndpoints 중 하나인 경우 true를 반환하고, 그렇지 않으면 false를 반환함

--- a/service-user/src/main/java/com/team13/serviceuser/service/SignInService.java
+++ b/service-user/src/main/java/com/team13/serviceuser/service/SignInService.java
@@ -17,6 +17,7 @@ import jakarta.transaction.Transactional;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
 
@@ -34,6 +35,9 @@ public class SignInService {
 
     //비밀번호 인코딩
     private final BCryptPasswordEncoder encoder;
+
+    @Value("${app.cookie.domain}")
+    private String cookieDomain;
 
     public SignInService(@Value("${app.jwt.secret}") String tokenSecret,
                          @Value("${app.jwt.keep}") long tokenKeepDuration,
@@ -82,22 +86,26 @@ public class SignInService {
         log.debug("Generated JWT: {}", token);
 
         // 기존 LTK 쿠키 삭제
-        Cookie deleteCookie = new Cookie("LTK", null);
-        deleteCookie.setMaxAge(0); // 즉시 만료
-        deleteCookie.setHttpOnly(true); // 동일한 옵션 설정
-        deleteCookie.setSecure(true);  // 동일한 옵션 설정
-        deleteCookie.setPath("/");     // 경로 설정 (루트 경로)
-        deleteCookie.setDomain("localhost"); // 도메인 설정
-        response.addCookie(deleteCookie);
+        ResponseCookie deleteCookie = ResponseCookie.from("LTK", "")
+                .httpOnly(true)
+                .secure(false)  // ✅ 로컬에서는 false (HTTPS가 아니므로)
+                .path("/")
+                .domain(cookieDomain)
+                .maxAge(0) // 즉시 만료
+                .sameSite("None")  // ✅ SameSite=None 추가
+                .build();
+        response.addHeader(HttpHeaders.SET_COOKIE, deleteCookie.toString());
 
         // 새로운 LTK 쿠키 생성
-        Cookie newCookie = new Cookie("LTK", token);
-        newCookie.setHttpOnly(true);
-        newCookie.setSecure(true); // HTTPS 환경에서만 전달
-        newCookie.setPath("/"); // 루트 경로
-        newCookie.setDomain("localhost"); // 도메인 설정
-        newCookie.setMaxAge((int) tokenKeepDuration / 1000); // 초 단위 만료 시간
-        response.addCookie(newCookie);
+        ResponseCookie newCookie = ResponseCookie.from("LTK", token)
+                .httpOnly(true)
+                .secure(false)  // ✅ 서버에서는 true (HTTPS 환경)
+                .path("/")
+                .domain(cookieDomain)  // ✅ 도메인 설정: n1.junyeong.dev
+                .maxAge(tokenKeepDuration / 1000)
+                .sameSite("None")  // ✅ SameSite=None 추가 (CORS 문제 방지)
+                .build();
+        response.addHeader(HttpHeaders.SET_COOKIE, newCookie.toString());
 
         log.debug("LTK Cookie set with new JWT token.");
     }

--- a/service-user/src/main/resources/application.yml
+++ b/service-user/src/main/resources/application.yml
@@ -3,7 +3,9 @@ app:
     url: http://localhost:3964
   server-eureka:
     url: http://localhost:3743/eureka/
-
+  cookie:
+#    domain: "n1.junyeong.dev"
+    domain: "localhost"
 server:
   port: 7234
 
@@ -41,3 +43,6 @@ logging:
     com.team13.serviceuser.service.SignInService: DEBUG # SignInService 클래스의 로그 레벨 설정
   pattern:
     console: "%d{yyyy-MM-dd HH:mm:ss} %-5level %logger{36} - %msg%n" # 로그 출력 포맷
+
+
+

--- a/service-user/src/main/resources/application.yml
+++ b/service-user/src/main/resources/application.yml
@@ -4,8 +4,11 @@ app:
   server-eureka:
     url: http://localhost:3743/eureka/
   cookie:
-    domain: "n1.junyeong.dev"
+    domain: "n1-beta.junyeong.dev"
+#    domain: "n1.junyeong.dev"
 #    domain: "localhost"
+
+
 server:
   port: 7234
 

--- a/service-user/src/main/resources/application.yml
+++ b/service-user/src/main/resources/application.yml
@@ -4,8 +4,8 @@ app:
   server-eureka:
     url: http://localhost:3743/eureka/
   cookie:
-    domain: "n1-beta.junyeong.dev"
-#    domain: "n1.junyeong.dev"
+#    domain: "n1-beta.junyeong.dev"
+    domain: "n1.junyeong.dev"
 #    domain: "localhost"
 
 

--- a/service-user/src/main/resources/application.yml
+++ b/service-user/src/main/resources/application.yml
@@ -4,8 +4,8 @@ app:
   server-eureka:
     url: http://localhost:3743/eureka/
   cookie:
-#    domain: "n1.junyeong.dev"
-    domain: "localhost"
+    domain: "n1.junyeong.dev"
+#    domain: "localhost"
 server:
   port: 7234
 


### PR DESCRIPTION
## Type
기능 추가 / 버그 수정 / 코드 리팩토링
쿠키 도메인 localhost-> 서버 도메인으로 변경
## Description
변경 사항 혹은 수정사항을 간단하게 작성해주세요.
로컬에서는 로그인후 생성되는 토큰 값이 자동으로 쿠키에 저장돼서 전달이 되는데
서버상에서는 자동 전달이 안되는 상황입니다 
로컬에서도  쿠키 도메인이 로컬 서버인 localhost가 아니면 같은 상태이기 때문에 서버상 도메인과 서버 쿠키 도메인이 같으면 자동으로 될 것이라는 가설을 세우고 수정해서 pr올립니다
서버 상의 문제가 없는 것으로 확인되면 개발,배포 쿠키 도메인의 차이를 두겠습니다 현재는 확인용도로 모두 서버 도메인으로 변경했습니다!