### PR TITLE
feat: 유저앱 로거 변경 및 쿠키 로직 변경

### DIFF
--- a/service-user/src/main/java/com/team13/serviceuser/service/SignInService.java
+++ b/service-user/src/main/java/com/team13/serviceuser/service/SignInService.java
@@ -105,11 +105,11 @@ public class SignInService {
         // 새로운 LTK 쿠키 생성
         ResponseCookie newCookie = ResponseCookie.from("LTK", token)
                 .httpOnly(true)
-                .secure(cookieSecure)  // NOTE: false(개발기), true(OP)
+                .secure(cookieSecure)  // NOTE: false(DEV), true(OP)
                 .path("/")
-                .domain(cookieDomain)  // NOTE: "localhost"(개발기), "n1.junyeong.dev"(OP)
+                .domain(cookieDomain)  // NOTE: "localhost"(DEV), "n1.junyeong.dev"(OP)
                 .maxAge(tokenKeepDuration / 1000)
-                .sameSite(cookieSameSite) // NOTE: Lax(개발기), None(OP)
+                .sameSite(cookieSameSite) // NOTE: Strict(DEV), None(OP)
                 .build();
         response.addHeader(HttpHeaders.SET_COOKIE, newCookie.toString());
 

--- a/service-user/src/main/java/com/team13/serviceuser/service/SignInService.java
+++ b/service-user/src/main/java/com/team13/serviceuser/service/SignInService.java
@@ -5,13 +5,10 @@ import com.team13.serviceuser.apiPyaload.code.status.ErrorStatus;
 import com.team13.serviceuser.dto.SignRequest;
 import com.team13.serviceuser.entity.User;
 import com.team13.serviceuser.repository.UserRepository;
-import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.io.Decoders;
 import io.jsonwebtoken.security.Keys;
-import jakarta.servlet.http.Cookie;
-import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.transaction.Transactional;
 import lombok.extern.log4j.Log4j2;
@@ -36,6 +33,15 @@ public class SignInService {
     //비밀번호 인코딩
     private final BCryptPasswordEncoder encoder;
 
+    // NOTE: 쿠키 Samesite 옵션
+    @Value("${app.cookie.same-site}")
+    private String cookieSameSite;
+
+    // NOTE: 쿠키 Secure 옵션
+    @Value("${app.cookie.secure}")
+    private boolean cookieSecure;
+
+    // NOTE: 쿠키 도메인
     @Value("${app.cookie.domain}")
     private String cookieDomain;
 
@@ -88,22 +94,22 @@ public class SignInService {
         // 기존 LTK 쿠키 삭제
         ResponseCookie deleteCookie = ResponseCookie.from("LTK", "")
                 .httpOnly(true)
-                .secure(false)  // 로컬에서는 false (HTTPS가 아니므로)
+                .secure(cookieSecure)
                 .path("/")
                 .domain(cookieDomain)
                 .maxAge(0) // 즉시 만료
-                .sameSite("None")
+                .sameSite(cookieSameSite)
                 .build();
         response.addHeader(HttpHeaders.SET_COOKIE, deleteCookie.toString());
 
         // 새로운 LTK 쿠키 생성
         ResponseCookie newCookie = ResponseCookie.from("LTK", token)
                 .httpOnly(true)
-                .secure(false)  // 서버에서는 true (HTTPS 환경)
+                .secure(cookieSecure)  // NOTE: false(개발기), true(OP)
                 .path("/")
-                .domain(cookieDomain)
+                .domain(cookieDomain)  // NOTE: "localhost"(개발기), "n1.junyeong.dev"(OP)
                 .maxAge(tokenKeepDuration / 1000)
-                .sameSite("None")  //  SameSite=None 추가 (CORS 문제 방지)
+                .sameSite(cookieSameSite) // NOTE: Lax(개발기), None(OP)
                 .build();
         response.addHeader(HttpHeaders.SET_COOKIE, newCookie.toString());
 

--- a/service-user/src/main/resources/application.yml
+++ b/service-user/src/main/resources/application.yml
@@ -34,14 +34,5 @@ eureka:
     service-url:
       defaultZone: ${app.server-eureka.url}
 
-#logging:
-#  config: classpath:log4j2/log4j2-${spring.profiles.active}.properties
 logging:
-  level:
-    root: INFO
-    com.team13.serviceuser.service.SignInService: DEBUG # SignInService 클래스의 로그 레벨 설정
-  pattern:
-    console: "%d{yyyy-MM-dd HH:mm:ss} %-5level %logger{36} - %msg%n" # 로그 출력 포맷
-
-
-
+  config: classpath:log4j2/log4j2-${spring.profiles.active}.properties


### PR DESCRIPTION
## Type
기능 추가

## Description

* 유저앱에 log4j2 로거를 기본으로 사용하도록 변경
* LTK 쿠키를 저장할 때 지정하는 옵션(`SameSite`, `Secure`)을 환경별 분기

### [DEV] SameSite, Secure 옵션
* `SameSite`는 `Strict`, `Secure`는 `false`로 지정
* 개발기의 쿠키 `domain`은 `localhost`이므로, 해당 도메인으로 쿠키 제한
* 개발단에서는 localhost를 사용하기에 https를 사용할 수 없어, `Secure`로 `false`를 가짐

### [OP] SameSite, Secure 옵션
* `SameSite`는 `None`, `Secure`는 `true`로 지정
* OP환경의 쿠키 `domain`은 `n1.junyeong.dev`이지만, 프론트엔드 작업을 위해 임시로 `SameSite`를 `None`으로 지정
  * `SameSite`를 `None`으로 지정 시, 프론트엔드 개발단(localhost)에서도 쿠키를 저장할 수 있음
* 또한, `SameSite`가 `None`인 경우 `Secure` 옵션은 무조건 `true`이어야 하므로, 이와 같이 지정
* 해당 부분은 최종 프로젝트 완성 시에 `SameSite`를 `Strict`로 변경이 필요함
