### PR TITLE
feat: LUSER 쿠키 추가 및 공동구매 마감 날짜 데이터 추가

### DIFF
--- a/service-post/src/main/java/com/team13/servicepost/controller/IndexController.java
+++ b/service-post/src/main/java/com/team13/servicepost/controller/IndexController.java
@@ -102,13 +102,17 @@ public class IndexController {
             Post post = new Post();
             post.setId(postId);
 
+            Date createdAt = RandomPostGenerator.createdAt();
+            Date closedAt = RandomPostGenerator.closedAt(createdAt);
+
             posts.add(PostDto.builder()
                     .id(postId)
                     .status(RandomPostGenerator.status())
                     .userNickname(RandomPostGenerator.userNickname())
                     .groupSize(groupSize)
                     .curGroupSize(curGroupSize)
-                    .createdAt(RandomPostGenerator.createdAt())
+                    .createdAt(createdAt)
+                    .closedAt(closedAt)
                     .locationLongitude(RandomPostGenerator.locationLongitude())
                     .locationLatitude(RandomPostGenerator.locationLatitude())
                     .title(RandomPostGenerator.title())

--- a/service-user/src/main/java/com/team13/serviceuser/controller/SignController.java
+++ b/service-user/src/main/java/com/team13/serviceuser/controller/SignController.java
@@ -91,7 +91,8 @@ public class SignController {
 
         // 로그인 성공 시 쿠키 생성
         User user = (User) apiResponse.getResult();
-        signInService.createCookieFromUser(user, response);
+        signInService.createCookieFromUser(user, response);  // LTK 쿠키
+        signInService.createLoginUserCookie(user, response); // 로그인 여부 확인을 위한 쿠키
 
         return ResponseEntity.ok(ApiResponse.onSuccess("로그인 성공"));
     }

--- a/service-user/src/main/java/com/team13/serviceuser/service/SignInService.java
+++ b/service-user/src/main/java/com/team13/serviceuser/service/SignInService.java
@@ -116,6 +116,19 @@ public class SignInService {
         log.debug("LTK Cookie set with new JWT token.");
     }
 
+    // 사용자 ID를 담고있는 LUSER(Login User) 쿠키 생성
+    public void createLoginUserCookie(User user, HttpServletResponse response) {
+        ResponseCookie lUserCookie = ResponseCookie.from("LUSER", user.getId().toString())
+                .secure(cookieSecure)  // NOTE: false(DEV), true(OP)
+                .path("/")
+                .domain(cookieDomain)  // NOTE: "localhost"(DEV), "n1.junyeong.dev"(OP)
+                .maxAge(tokenKeepDuration / 1000)
+                .sameSite(cookieSameSite) // NOTE: Strict(DEV), None(OP)
+                .build();
+
+        response.addHeader(HttpHeaders.SET_COOKIE, lUserCookie.toString());
+    }
+
     // JWT 쿠키 삭제 메서드 추가
     public void clearAuthCookie(HttpServletResponse response) {
         ResponseCookie deleteCookie = ResponseCookie.from("LTK", "")


### PR DESCRIPTION
## Type
기능 추가

## Description

### LUSER 쿠키 추가
기존의 LTK 쿠키는 HttpOnly 쿠키로, 프론트 단에서는 해당 쿠키에 대한 접근을 할 수 없습니다. 따라서, LTK 쿠키와 함께 LUSER(Login User) 쿠키를 추가하여 프론트 단에서 현재 사용자가 로그인 상태인지를 확인할 수 있도록 구현하였습니다.

### 공동구매 마감 날짜 데이터 추가
현재 공동구매 게시글 리스트를 반환할 때 각 공동구매의 마감 날짜를 지정하지 않고 있어, 이 부분을 추가하였습니다.